### PR TITLE
Remove the speed check in IsInWorld for grenades/projectiles

### DIFF
--- a/dlls/baseentity.h
+++ b/dlls/baseentity.h
@@ -946,7 +946,7 @@ public:
 	virtual bool	IsTemplate( void ) { return false; }
 	virtual bool	IsBaseObject( void ) const { return false; }
 	bool			IsBSPModel() const;
-	bool			IsInWorld( void ) const;
+	virtual bool	IsInWorld( void ) const;
 
 	// If this is a vehicle, returns the vehicle interface
 	virtual IServerVehicle*			GetServerVehicle() { return NULL; }

--- a/game_shared/basegrenade_shared.cpp
+++ b/game_shared/basegrenade_shared.cpp
@@ -87,7 +87,9 @@ BEGIN_NETWORK_TABLE( CBaseGrenade, DT_BaseGrenade )
 
 	SendPropFloat		( SENDINFO_VECTORELEM(m_vecVelocity, 0), 13, SPROP_CHANGES_OFTEN|SPROP_ROUNDDOWN, -1024.0f, 1024.0f ),
 	SendPropFloat		( SENDINFO_VECTORELEM(m_vecVelocity, 1), 13, SPROP_CHANGES_OFTEN|SPROP_ROUNDDOWN, -1024.0f, 1024.0f ),
-	SendPropFloat		( SENDINFO_VECTORELEM(m_vecVelocity, 2), 14, SPROP_CHANGES_OFTEN|SPROP_ROUNDDOWN, -3072.0f, 1024.0f ),
+	// --> squeek: Increase negative Z bounds to match player bounds (fixes DataTable Out-of-range value warnings due to sv_maxvelocity being defaulted to 3500)
+	SendPropFloat		( SENDINFO_VECTORELEM(m_vecVelocity, 2), 14, SPROP_CHANGES_OFTEN|SPROP_ROUNDDOWN, /*-3072.0f*/ -4096.0f, 1024.0f ),
+	// <--
 
 	SendPropFloat		( SENDINFO_VECTORELEM(m_angRotation, 0), 9, SPROP_CHANGES_OFTEN|SPROP_ROUNDDOWN, 0.0f, 360.0f, SendProxy_AngleToFloat ),
 	SendPropFloat		( SENDINFO_VECTORELEM(m_angRotation, 1), 9, SPROP_CHANGES_OFTEN|SPROP_ROUNDDOWN, 0.0f, 360.0f, SendProxy_AngleToFloat ),

--- a/game_shared/ff/ff_projectile_base.cpp
+++ b/game_shared/ff/ff_projectile_base.cpp
@@ -195,6 +195,25 @@ END_NETWORK_TABLE()
 		UTIL_Remove(this);
 		return m_flDamage;
 	}
+
+	/** Override CBaseEntity::IsInWorld to ignore speed
+		Fixes grenades disappearing when they fall too far
+	*/
+	bool CFFProjectileBase::IsInWorld( void ) const
+	{
+		if ( !edict() )
+			return true;
+
+		// position 
+		if (GetAbsOrigin().x >= MAX_COORD_INTEGER) return false;
+		if (GetAbsOrigin().y >= MAX_COORD_INTEGER) return false;
+		if (GetAbsOrigin().z >= MAX_COORD_INTEGER) return false;
+		if (GetAbsOrigin().x <= MIN_COORD_INTEGER) return false;
+		if (GetAbsOrigin().y <= MIN_COORD_INTEGER) return false;
+		if (GetAbsOrigin().z <= MIN_COORD_INTEGER) return false;
+
+		return true;
+	}
 #endif
 
 //----------------------------------------------------------------------------

--- a/game_shared/ff/ff_projectile_base.h
+++ b/game_shared/ff/ff_projectile_base.h
@@ -81,6 +81,7 @@ private:
 	// sit still until it had gotten a few updates from the server.
 	void SetupInitialTransmittedVelocity(const Vector &velocity);
 	int TakeEmp();
+	virtual bool IsInWorld( void ) const;
 
 #endif
 


### PR DESCRIPTION
- Fixes #22: Grenades disappearing after falling too far
