### PR TITLE
Better info_ff_script bounds

### DIFF
--- a/dlls/ff/ff_item_flag.cpp
+++ b/dlls/ff/ff_item_flag.cpp
@@ -39,7 +39,7 @@ extern "C"
 
 #include "tier0/memdbgon.h"
 
-ConVar ffdev_visualize_infoscript_sizes( "ffdev_visualize_infoscript_sizes", "0", FCVAR_FF_FFDEV );
+ConVar ffdev_visualize_infoscript_sizes( "ffdev_visualize_infoscript_sizes", "0", FCVAR_CHEAT );
 #define VISUALIZE_INFOSCRIPT_SIZES ffdev_visualize_infoscript_sizes.GetBool()
 
 #define ITEM_PICKUP_BOX_BLOAT 12 // default; only used if no lua function exists

--- a/dlls/ff/ff_item_flag.h
+++ b/dlls/ff/ff_item_flag.h
@@ -160,6 +160,7 @@ public:
 	bool CanEntityTouch(CBaseEntity* pEntity);
 
 	virtual void	ResolveFlyCollisionCustom( trace_t &trace, Vector &vecVelocity );
+	virtual void	PhysicsSimulate( void );
 
 	// bot info accessors
 	int GetBotTeamFlags() const { return m_BotTeamFlags; }
@@ -173,6 +174,7 @@ protected:
 	virtual void	SetReturned( void );
 	virtual void	SetDropped( void );
 
+	void MakeTouchable();
 	bool CreateItemVPhysicsObject( void );
 
 	void PlayDroppedAnim( void );
@@ -194,6 +196,11 @@ protected:
 	QAngle m_vStartAngles;
 	Vector	m_vecMins;
 	Vector	m_vecMaxs;
+	Vector	m_vecPhysicsMins;
+	Vector	m_vecPhysicsMaxs;
+	Vector	m_vecTouchMins;
+	Vector	m_vecTouchMaxs;
+	float	m_flHitboxBloat;
 
 	CBaseEntity *m_pLastOwner;
 	

--- a/dlls/ff/ff_luacontext.cpp
+++ b/dlls/ff/ff_luacontext.cpp
@@ -134,6 +134,9 @@ void CFFLuaSC::Push(QAngle angle) { m_params.AddToTail(SETOBJECT(angle)); }
 void CFFLuaSC::Push(const CTakeDamageInfo* pInfo) { m_params.AddToTail(SETOBJECT(pInfo)); }
 
 //---------------------------------------------------------------------------
+void CFFLuaSC::PushRef(luabind::adl::object& luabindObject) { m_params.AddToTail(SETOBJECTREF(luabindObject)); }
+void CFFLuaSC::PushRef(Vector &vector) { m_params.AddToTail(SETOBJECTREF(vector)); }
+void CFFLuaSC::PushRef(QAngle &angle) { m_params.AddToTail(SETOBJECTREF(angle)); }
 void CFFLuaSC::PushRef(CTakeDamageInfo& info) { m_params.AddToTail(SETOBJECTREF(info)); }
 
 //---------------------------------------------------------------------------

--- a/dlls/ff/ff_luacontext.h
+++ b/dlls/ff/ff_luacontext.h
@@ -72,6 +72,9 @@ public:
 
 	// pushes a parameter by reference in preparation for a function call
 	void PushRef(CTakeDamageInfo& info);
+	void PushRef(luabind::adl::object& luabindObject);
+	void PushRef(Vector &vector);
+	void PushRef(QAngle &angle);
 
 	// returns the number of parameters
 	int GetNumParams() const { return m_params.Count(); }


### PR DESCRIPTION
Flags getting stuck in ceilings was caused by the flag bounds being 1 unit high while moving, then momentarily having 0 velocity while inside a ceiling, which caused its bounds to get reset and would get it stuck.

Walking right through thrown flags without catching them was caused by the 1 unit high flag size also being applied to the trigger/touch size. The touch size would only get set back to full once the flag velocity reached zero.

If I remember right, this decouples the trigger size from the physics size, allowing for a 1 unit high physics size while maintaining a constant trigger size. It also puts the control of the size in the hands of Lua, meaning that resupply bags/etc (which are also info_ff_scripts) can have different trigger bloat than flags.

From the commit message:
- Fixed flags getting stuck in ceilings
- Fixed flag touch bounds being 1 unit high while the flag is moving (it used to only get reset to the correct size once it had 0 velocity)
- Added support for separate collision and touch bounds for info_ff_scripts, but it's kind of a hacky way to do it (set size before physics calculations and then reset it after). The sizes are now controlled by Lua functions:
  - <entity_name>:gettouchsizes( mins, maxs ) passes min and max vectors by reference for the function to alter in place
  - <entity_name>:getphysicssizes( mins, maxs ) passes min and max vectors by reference for the function to alter in place
  - <entity_name>:getbloatsize() expects a float return value, uses the value to inflate the touch bounding box (default bloat is 12)
