### PR TITLE
Reduce jump-pad horizontal push

### DIFF
--- a/dlls/ff/ff_mancannon.cpp
+++ b/dlls/ff/ff_mancannon.cpp
@@ -45,8 +45,8 @@ extern const char *g_pszFFManCannonSounds[];
 
 extern const char *g_pszFFGenGibModels[];
 
-//ConVar ffdev_mancannon_push_forward( "ffdev_mancannon_push_forward", "1024", FCVAR_FF_FFDEV_REPLICATED );
-#define MANCANNON_PUSH_FORWARD 1024 //ffdev_mancannon_push_forward.GetInt()
+ConVar ffdev_mancannon_push_forward( "ffdev_mancannon_push_forward", "700", FCVAR_FF_FFDEV_REPLICATED );
+#define MANCANNON_PUSH_FORWARD ffdev_mancannon_push_forward.GetInt()
 //ConVar ffdev_mancannon_push_up( "ffdev_mancannon_push_up", "512", FCVAR_FF_FFDEV_REPLICATED );
 #define MANCANNON_PUSH_UP 512 //ffdev_mancannon_push_up.GetInt()
 //ConVar ffdev_mancannon_health( "ffdev_mancannon_health", "150", FCVAR_FF_FFDEV_REPLICATED );

--- a/dlls/ff/ff_mancannon.cpp
+++ b/dlls/ff/ff_mancannon.cpp
@@ -45,7 +45,7 @@ extern const char *g_pszFFManCannonSounds[];
 
 extern const char *g_pszFFGenGibModels[];
 
-ConVar ffdev_mancannon_push_forward( "ffdev_mancannon_push_forward", "700", FCVAR_FF_FFDEV_REPLICATED );
+ConVar ffdev_mancannon_push_forward( "ffdev_mancannon_push_forward", "600", FCVAR_FF_FFDEV_REPLICATED );
 #define MANCANNON_PUSH_FORWARD ffdev_mancannon_push_forward.GetInt()
 //ConVar ffdev_mancannon_push_up( "ffdev_mancannon_push_up", "512", FCVAR_FF_FFDEV_REPLICATED );
 #define MANCANNON_PUSH_UP 512 //ffdev_mancannon_push_up.GetInt()

--- a/game_shared/ff/ff_grenade_concussion.cpp
+++ b/game_shared/ff/ff_grenade_concussion.cpp
@@ -43,7 +43,7 @@
 // #0001629: Request: Dev variables for HH conc strength |-- Defrag
 
 //ConVar ffdev_mancannon_conc_speed( "ffdev_mancannon_conc_speed", "1700.0", FCVAR_FF_FFDEV_REPLICATED, "Max conc speed a player can attain after just using a jump pad." );
-#define MAX_JUMPPAD_TO_CONC_SPEED 1700.0f // ffdev_mancannon_conc_speed.GetFloat()
+#define MAX_JUMPPAD_TO_CONC_SPEED 1400.0f // ffdev_mancannon_conc_speed.GetFloat()
 //static ConVar ffdev_conc_lateral_power( "ffdev_conc_lateral_power", "2.74", FCVAR_FF_FFDEV, "Lateral movement boost value for hand-held concs", true, 0.0f, true, 2.74f );
 #define FFDEV_CONC_LATERAL_POWER 2.74f //ffdev_conc_lateral_power.GetFloat() //2.74f
 //static ConVar ffdev_conc_vertical_power( "ffdev_conc_vertical_power", "4.10", FCVAR_FF_FFDEV, "Vertical movement boost value for hand-held concs", true, 0.0f, true, 4.10f );


### PR DESCRIPTION
https://github.com/fortressforever/fortressforever/issues/30
The idea here is to keep the good stuff about the jump pad:
- Give new players enough air time to easily access the "movement skill" part of FF, get used to air control, etc
- Make the scout less of a lone wolf and tie him to the team a little more
- Give the scout a purpose on AvD maps

Whilst reducing the impact:
- Reduce the impact of the jump pad on AvD especially on public servers
- Reduce the impact and usefulness of the jump pad on CTF in pickup / competitive situations

I have exposed the cvar in case anyone wants to experiment for themselves. I found 600 to be a good speed because:
- It's faster than a medic/scout bhop, so as a medic, it's worth taking
- It's slow enough that you shouldnt take a massive detour to use it
