### PR TITLE
Reduce skim - bhop_cap_hard reduced from 2.0 to 1.9

### DIFF
--- a/cl_dll/ff/ff_hud_speedometer.cpp
+++ b/cl_dll/ff/ff_hud_speedometer.cpp
@@ -26,7 +26,7 @@
 
 // ELMO *** 
 #define BHOP_CAP_SOFT 1.4f // as defined in ff_gamemovement.cpp
-#define BHOP_CAP_HARD 2.0f // as defined in ff_gamemovement.cpp
+#define BHOP_CAP_HARD 1.9f // as defined in ff_gamemovement.cpp
 // *** ELMO
 
 // memdbgon must be the last include file in a .cpp file!!!

--- a/game_shared/ff/ff_gamemovement.cpp
+++ b/game_shared/ff/ff_gamemovement.cpp
@@ -91,10 +91,10 @@ public:
 
 //static ConVar bhop_cap_soft("ffdev_bhop_cap_soft", "1.4", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_soft.GetFloat()
 #define BHOP_CAP_SOFT 1.4f // also defined in ff_hud_speedometer - change it there too! 
-//static ConVar bhop_cap_hard("ffdev_bhop_cap_hard", "2.0", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard.GetFloat()
-#define BHOP_CAP_HARD 1.9f // also defined in ff_hud_speedometer - change it there too!
-//static ConVar bhop_cap_hard_degen("ffdev_bhop_cap_hard_degen", "0.9", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard_degen.GetFloat()
-#define	BHOP_CAP_HARD_DEGEN 0.9
+//static ConVar bhop_cap_hard("ffdev_bhop_cap_hard", "1.71", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard.GetFloat()
+#define BHOP_CAP_HARD 1.71f // also defined in ff_hud_speedometer - change it there too!
+//static ConVar bhop_cap_hard_result("ffdev_bhop_cap_hard_result", "1.71", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard.GetFloat()
+#define BHOP_CAP_HARD_RESULT 1.71f // also defined in ff_hud_speedometer - change it there too!
 //static ConVar bhop_pcfactor("ffdev_bhop_pcfactor", "0.65", FCVAR_FF_FFDEV_REPLICATED); // bhop_pcfactor.GetFloat()
 #define BHOP_PCFACTOR 0.65 
 
@@ -373,7 +373,7 @@ bool CFFGameMovement::CheckJumpButton(void)
 			// apply skim cap
 			if (speed > cap_hard )
 			{
-				float applied_cap = cap_hard * BHOP_CAP_HARD_DEGEN; 
+				float applied_cap = BHOP_CAP_HARD_RESULT * mv->m_flMaxSpeed;; 
 				float multi = applied_cap / speed;
 
 				mv->m_vecVelocity[0] *= multi;

--- a/game_shared/ff/ff_gamemovement.cpp
+++ b/game_shared/ff/ff_gamemovement.cpp
@@ -92,7 +92,7 @@ public:
 //static ConVar bhop_cap_soft("ffdev_bhop_cap_soft", "1.4", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_soft.GetFloat()
 #define BHOP_CAP_SOFT 1.4f // also defined in ff_hud_speedometer - change it there too! 
 //static ConVar bhop_cap_hard("ffdev_bhop_cap_hard", "2.0", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard.GetFloat()
-#define BHOP_CAP_HARD 2.0f // also defined in ff_hud_speedometer - change it there too!
+#define BHOP_CAP_HARD 1.9f // also defined in ff_hud_speedometer - change it there too!
 //static ConVar bhop_cap_hard_degen("ffdev_bhop_cap_hard_degen", "0.9", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard_degen.GetFloat()
 #define	BHOP_CAP_HARD_DEGEN 0.9
 //static ConVar bhop_pcfactor("ffdev_bhop_pcfactor", "0.65", FCVAR_FF_FFDEV_REPLICATED); // bhop_pcfactor.GetFloat()


### PR DESCRIPTION
This reduces the skim after a conc slightly. This means after conc skim 1 they are travelling at 684 speed rather than 720. This is actually 171% of movement speed rather than 190% due to the 0.9 degen multiplier but still a fair bit higher than TFC which nerfs you back to 100% speed after a conc.
