### PR TITLE
fixed ff_training not showing map loading info

### DIFF
--- a/cl_dll/ff/vgui/ff_training.cpp
+++ b/cl_dll/ff/vgui/ff_training.cpp
@@ -72,6 +72,7 @@ void CFFTrainingPanel::OnButtonCommand(KeyValues *data)
 		engine->ClientCmd("sv_lan 1\n");
 		engine->ClientCmd("mp_timelimit 0\n");
 		engine->ClientCmd("sv_cheats 0\n");
+		engine->ClientCmd("progress_enable 1\n");
 		engine->ClientCmd("map ff_training\n");
 		// Just make it invisible now...
 		SetVisible(false);


### PR DESCRIPTION
See #10 just need to add 
engine->ClientCmd("progress_enable 1\n"); 
