### PR TITLE
Added sparks to the feet of rampsliders

### DIFF
--- a/game_shared/ff/ff_gamemovement.cpp
+++ b/game_shared/ff/ff_gamemovement.cpp
@@ -18,6 +18,7 @@
 #include "in_buttons.h"
 #include "movevars_shared.h"
 #include "ff_mapguide.h"
+#include "IEffects.h"
 
 #define	STOP_EPSILON		0.1
 #define	MAX_CLIP_PLANES		5
@@ -85,6 +86,7 @@ public:
 	virtual void WalkMove();
 	virtual void AirMove();
 	virtual void Friction();
+	bool IsRampSliding( CFFPlayer *pPlayer );
 
 	CFFGameMovement() {};
 };
@@ -901,6 +903,42 @@ bool CFFGameMovement::CanAccelerate()
 	return true;
 }
 
+bool CFFGameMovement::IsRampSliding( CFFPlayer *pPlayer )
+{
+	if (pPlayer->GetGroundEntity() == NULL)  // Rampsliding occurs when normal ground detection fails
+	{
+		// Take the lateral velocity
+		Vector vecVelocity = mv->m_vecVelocity * Vector(1.0f, 1.0f, 0.0f);
+		float flHorizontalSpeed = vecVelocity.Length();
+
+		if (flHorizontalSpeed > SV_TRIMPTRIGGERSPEED)
+		{
+			trace_t pm;
+
+			Vector vecStart = mv->m_vecAbsOrigin;
+			Vector vecStop = vecStart - Vector(0, 0, 0.1f);
+			
+			TracePlayerBBox(vecStart, vecStop, MASK_PLAYERSOLID, COLLISION_GROUP_PLAYER_MOVEMENT, pm); // but actually you are on the ground
+
+			// Found the floor
+			if(pm.fraction != 1.0f)
+			{
+				if (flHorizontalSpeed > 0)
+					vecVelocity /= flHorizontalSpeed;
+
+				float flDotProduct = DotProduct(vecVelocity, pm.plane.normal);
+				if (flDotProduct < -0.15f) // On an upwards ramp
+				{
+					return true;
+				}
+			}
+		}
+		
+	}
+
+	return false;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Check player velocity & clamp if cloaked
 //-----------------------------------------------------------------------------
@@ -914,7 +952,12 @@ void CFFGameMovement::CheckVelocity( void )
 	CFFPlayer *pPlayer = ToFFPlayer( player );
 	if( !pPlayer )
 		return;
-	
+#ifdef CLIENT_DLL
+	if (IsRampSliding(pPlayer))
+	{
+		g_pEffects->Sparks(pPlayer->GetAbsOrigin());
+	}
+#endif
 	if( !pPlayer->IsCloaked() )
 		return;
 
@@ -927,7 +970,6 @@ void CFFGameMovement::CheckVelocity( void )
 		mv->m_vecVelocity.y *= 0.5f;
 	}
 }
-
 // Expose our interface.
 static CFFGameMovement g_GameMovement;
 IGameMovement *g_pGameMovement = ( IGameMovement * )&g_GameMovement;


### PR DESCRIPTION
Kind of a bit of a hacky method to detect whether a player is rampsliding. If anyone has a better method, let me know. Currently its:
- If your ground entity is null AND
- If doing a trace straight downwards 0.1 units hits the floor AND
- If you are moving above 550 speed AND
- You are on an upwards slope

I wasn't sure whether to attach a sound also. It might be kind of cool to have a subtle sound when a player is rampsliding - currently you get complete silence, which is a bit weird?
