### PR TITLE
Use JumpPad-specific soundscript definitions for build/explode sounds

### DIFF
--- a/game_shared/ff/ff_buildableobjects_shared.h
+++ b/game_shared/ff/ff_buildableobjects_shared.h
@@ -88,8 +88,8 @@
 #define FF_SENTRYGUN_EXPLODE_SOUND			"Sentry.Explode"
 
 #define FF_MANCANNON_MODEL					"models/items/jumppad/jumppad.mdl"
-#define FF_MANCANNON_BUILD_SOUND			"Detpack.Build"
-#define FF_MANCANNON_EXPLODE_SOUND			"Detpack.Explode"
+#define FF_MANCANNON_BUILD_SOUND			"JumpPad.Build"
+#define FF_MANCANNON_EXPLODE_SOUND			"JumpPad.Explode"
 
 //#define FF_SENTRYGUN_AIMSPHERE_MODEL		"models/buildable/sg/sentrygun_aimsphere.mdl"
 


### PR DESCRIPTION
A simple little change that allows people to customize jump pad sounds without having to alter the detpack sounds as well. Requested by R00Kie/@BleuJudou

Requires soundscript definitions that are already committed: https://github.com/fortressforever/fortressforever-scripts/commit/24438e3e4526ef33a02ab26802108f20efd34f6c
