### PR TITLE
Fix conc speed being limited for too long after using a jump pad

### DIFF
--- a/dlls/ff/ff_mancannon.cpp
+++ b/dlls/ff/ff_mancannon.cpp
@@ -205,6 +205,7 @@ void CFFManCannon::OnObjectTouch( CBaseEntity *pOther )
 	// add an amount to their horizontal + vertical velocity (dont multiply cos slow classes wouldnt go anywhere!)
 	//pPlayer->ApplyAbsVelocityImpulse( (vecForward * ffdev_mancannon_push_forward.GetFloat()) + Vector( 0, 0, ffdev_mancannon_push_up.GetFloat() ) );
 
+	pPlayer->SetGroundEntity( (CBaseEntity *)NULL );
 	pPlayer->SetAbsVelocity((vecForward * MANCANNON_PUSH_FORWARD) + Vector( 0, 0, MANCANNON_PUSH_UP ) );
 	
 	//Vector vecVelocity = pPlayer->GetAbsVelocity();

--- a/game_shared/ff/ff_grenade_concussion.cpp
+++ b/game_shared/ff/ff_grenade_concussion.cpp
@@ -367,7 +367,7 @@ PRECACHE_WEAPON_REGISTER(ff_grenade_concussion);
 			// AfterShock: This takes into account vertical speed too, limiting horizontal speed if you're going upwards aswell
 			//             is this a bad thing? 
 #ifdef GAME_DLL
-			if ( pPlayer->m_flMancannonTime && gpGlobals->curtime < pPlayer->m_flMancannonTime + 5.2f )
+			if ( pPlayer->m_flMancannonTime && gpGlobals->curtime < pPlayer->m_flMancannonTime + 3.0f )
 			{
 				if ( vecResult.Length() > MAX_JUMPPAD_TO_CONC_SPEED )
 				{


### PR DESCRIPTION
- Fixes #80
- Will stop limiting once the player is on the ground or in water, or after 3 seconds has passed since the jump pad was used
- Also made the jump pad set players as in the air, so that m_flMancannonTime doesn't have to be checked in CFFGameMovement::CheckJumpButton (being in the air will force an early return)

**Notable side effect:** This allows a semi-exploit in that you can use a jump pad, land, and jump + conc to get a hard-cap-limited, full speed conc. I'm not sure how to get around that, as the old behavior was definitely buggy (it doesn't make sense to limit conc speed once you've landed from the jump pad boost). At the very least, it's way more interesting/dynamic than the old jump pad + conc combo mechanic.
