### PR TITLE
Default hud_fastswitch to 1 and add hud_weaponselect cvar

### DIFF
--- a/cl_dll/ff/ff_hud_weaponselection.cpp
+++ b/cl_dll/ff/ff_hud_weaponselection.cpp
@@ -51,6 +51,7 @@ public:
 	}
 
 	virtual void OpenSelection( void );
+	virtual void ShowSelection( void );
 	virtual void HideSelection( void );
 
 	virtual void LevelInit();
@@ -185,16 +186,14 @@ bool CHudWeaponSelection::ShouldDraw()
 		return false;
 	}
 
-	// --> Mirv: Always show if hud fastswitch is on
-	if (hud_fastswitch.GetInt() > 0)
-		return (gpGlobals->curtime < m_flSelectionTime + SELECTION_TIMEOUT_THRESHOLD + SELECTION_FADEOUT_TIME);
-	// <-- Mirv: Always show if hud fastswitch is on
-
 	bool bret = CBaseHudWeaponSelection::ShouldDraw();
 	if ( !bret )
 		return false;
 
-	return ( m_bSelectionVisible ) ? true : false;
+	if ( IsInSelectionMode() )
+		return true;
+
+	return gpGlobals->curtime < m_flSelectionTime + SELECTION_TIMEOUT_THRESHOLD + SELECTION_FADEOUT_TIME;
 }
 
 //-----------------------------------------------------------------------------
@@ -483,7 +482,12 @@ void CHudWeaponSelection::OpenSelection( void )
 	Assert(!IsInSelectionMode());
 
 	CBaseHudWeaponSelection::OpenSelection();
+}
+
+void CHudWeaponSelection::ShowSelection( void )
+{
 	g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("OpenWeaponSelectionMenu");
+	m_bFadingOut = false;
 }
 
 //-----------------------------------------------------------------------------

--- a/cl_dll/weapon_selection.cpp
+++ b/cl_dll/weapon_selection.cpp
@@ -21,7 +21,7 @@
 #define HISTORY_DRAW_TIME	"5"
 
 ConVar hud_drawhistory_time( "hud_drawhistory_time", HISTORY_DRAW_TIME, FCVAR_ARCHIVE );
-ConVar hud_fastswitch( "hud_fastswitch", "0", FCVAR_ARCHIVE, "0 = none | 1 = keyboard & mouse | 2 = keyboard only (old HL/TFC style)" );
+ConVar hud_fastswitch( "hud_fastswitch", "1", FCVAR_ARCHIVE, "0 = none | 1 = keyboard & mouse | 2 = keyboard only (old HL/TFC style)" );
 ConVar hud_weaponselect( "hud_weaponselect", "1", FCVAR_ARCHIVE, "Briefly shows the weapon select menu whenever switching weapons when hud_fastswitch is enabled" );
 
 //-----------------------------------------------------------------------------

--- a/cl_dll/weapon_selection.cpp
+++ b/cl_dll/weapon_selection.cpp
@@ -22,6 +22,7 @@
 
 ConVar hud_drawhistory_time( "hud_drawhistory_time", HISTORY_DRAW_TIME, FCVAR_ARCHIVE );
 ConVar hud_fastswitch( "hud_fastswitch", "0", FCVAR_ARCHIVE, "0 = none | 1 = keyboard & mouse | 2 = keyboard only (old HL/TFC style)" );
+ConVar hud_weaponselect( "hud_weaponselect", "1", FCVAR_ARCHIVE, "Briefly shows the weapon select menu whenever switching weapons when hud_fastswitch is enabled" );
 
 //-----------------------------------------------------------------------------
 // Purpose: Weapon Selection commands
@@ -112,6 +113,12 @@ void CBaseHudWeaponSelection::UpdateSelectionTime( void )
 	m_flSelectionTime = gpGlobals->curtime;
 }
 
+void CBaseHudWeaponSelection::QuicklyFadeOut( void )
+{
+	ShowSelection();
+	m_flSelectionTime = gpGlobals->curtime - 4.0f;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -191,6 +198,11 @@ bool CBaseHudWeaponSelection::IsInSelectionMode()
 void CBaseHudWeaponSelection::OpenSelection( void )
 {
 	m_bSelectionVisible = true;
+	ShowSelection();
+}
+
+void CBaseHudWeaponSelection::ShowSelection( void )
+{
 }
 
 //-----------------------------------------------------------------------------
@@ -348,10 +360,10 @@ void CBaseHudWeaponSelection::SelectSlot( int iSlot )
 
 	SelectWeaponSlot( iSlot );
 
-	// --> Mirv: On fast switch don't let this re-show the weapon select
 	if( hud_fastswitch.GetInt() == 0 )
 		UpdateSelectionTime();
-	// <-- Mirv: On fast switch don't let this re-show the weapon select
+	else if( hud_weaponselect.GetBool() )
+		QuicklyFadeOut();
 }
 
 //-----------------------------------------------------------------------------
@@ -390,7 +402,9 @@ void CBaseHudWeaponSelection::UserCmd_NextWeapon(void)
 	if( hud_fastswitch.GetInt() == 1 )
 	{
 		SelectWeapon();
-		m_flSelectionTime = gpGlobals->curtime - 4.0f;
+
+		if (hud_weaponselect.GetBool())
+			QuicklyFadeOut();
 	}
 	else
 //#endif
@@ -428,7 +442,9 @@ void CBaseHudWeaponSelection::UserCmd_PrevWeapon(void)
 	if( hud_fastswitch.GetInt() == 1 )
 	{
 		SelectWeapon();
-		m_flSelectionTime = gpGlobals->curtime - 4.0f;
+
+		if (hud_weaponselect.GetBool())
+			QuicklyFadeOut();
 	}
 	else
 //#endif
@@ -467,6 +483,9 @@ void CBaseHudWeaponSelection::SwitchToLastWeapon( void )
 	if (!player || !player->IsAlive() || player->GetTeamNumber() < TEAM_BLUE)
 		return;
 	// <-- Mirv: Don't select while dead
+
+	if (hud_weaponselect.GetBool())
+		QuicklyFadeOut();
 
 	input->MakeWeaponSelection( player->GetLastWeapon() );
 

--- a/cl_dll/weapon_selection.h
+++ b/cl_dll/weapon_selection.h
@@ -39,6 +39,7 @@ public:
 	virtual void OnThink(void);
 
 	virtual void OpenSelection( void );
+	virtual void ShowSelection( void );
 	virtual void HideSelection( void );
 
 	virtual void				CancelWeaponSelection( void );
@@ -98,6 +99,7 @@ protected:
 	bool	CanBeSelectedInHUD( C_BaseCombatWeapon *pWeapon );
 
 	void	UpdateSelectionTime( void );
+	void	QuicklyFadeOut( void );
 
 	float	m_flSelectionTime;	// most recent time at which weapon selection had input
 


### PR DESCRIPTION
- See #4 and http://forums.fortress-forever.com/showthread.php?t=24632

> Maybe we need a middle ground that shows the fastswitch HUD component when changing weapons, but doesn't require you to press fire to actually switch. 

That's what this is.
