### PR TITLE
Rampslide sparks (take 2)

### DIFF
--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -2457,7 +2457,7 @@ void C_FFPlayer::ClientThink( void )
 	// Hopefully when the particles die the ::Create()
 	// stuff gets removed automagically?
 
-	if (IsRampsliding())
+	if (IsRampsliding() && GetAbsVelocity().LengthSqr() > 0)
 	{
 		Vector vecDir = -GetAbsVelocity() / (GetAbsVelocity().LengthSqr() / 1000.0f);
 		g_pEffects->Sparks(GetFeetOrigin() + Vector(random->RandomFloat(-8, 8), random->RandomFloat(-8, 8), 0), 1, 1, &vecDir);

--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -856,6 +856,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_FFPlayer, DT_FFPlayer, CFFPlayer )
 	RecvPropBool( RECVINFO( m_bConcussed ) ),
 	RecvPropBool( RECVINFO( m_bTranqed ) ),
 	RecvPropBool( RECVINFO( m_bSliding ) ),
+	RecvPropBool( RECVINFO( m_bIsRampsliding ) ),
 	RecvPropEHandle( RECVINFO( m_hActiveSlowfield ) ),
 	RecvPropBool( RECVINFO( m_bInfected ) ),
 	RecvPropBool( RECVINFO( m_bImmune ) ),
@@ -1262,6 +1263,8 @@ C_FFPlayer::C_FFPlayer() :
 	
 	m_flSlidingTime = 0;
 	m_bSliding = false;
+
+	m_bIsRampsliding = false;
 
 	m_flSpeedModifier = 1.0f;
 	
@@ -2453,6 +2456,12 @@ void C_FFPlayer::ClientThink( void )
 {
 	// Hopefully when the particles die the ::Create()
 	// stuff gets removed automagically?
+
+	if (IsRampsliding())
+	{
+		Vector vecDir = -GetAbsVelocity() / (GetAbsVelocity().LengthSqr() / 1000.0f);
+		g_pEffects->Sparks(GetFeetOrigin() + Vector(random->RandomFloat(-8, 8), random->RandomFloat(-8, 8), 0), 1, 1, &vecDir);
+	}
 
 	// Update infection emitters
 	if( IsAlive() && IsInfected() && !IsImmune() && !IsDormant() )

--- a/cl_dll/ff/c_ff_player.h
+++ b/cl_dll/ff/c_ff_player.h
@@ -536,6 +536,7 @@ public:
 	void SetRampsliding( bool bIsRampsliding ) { m_bIsRampsliding = bIsRampsliding; }
 protected:
 	bool m_bIsRampsliding;
+	float m_flNextRampslideFX;
 
 	// ----------------------------------
 	// Cloak stuff

--- a/cl_dll/ff/c_ff_player.h
+++ b/cl_dll/ff/c_ff_player.h
@@ -25,6 +25,7 @@
 #include "ff_buildableobjects_shared.h"
 #include "ff_radiotagdata.h"
 #include "model_types.h"
+#include "IEffects.h"
 
 class C_FFBuildableObject;
 class C_FFDetpack;
@@ -529,6 +530,12 @@ protected:
 	bool m_bSliding;
 	// ----------------------------------
 // *** SQUEEK
+
+public:
+	bool IsRampsliding( void ) const { return m_bIsRampsliding; }
+	void SetRampsliding( bool bIsRampsliding ) { m_bIsRampsliding = bIsRampsliding; }
+protected:
+	bool m_bIsRampsliding;
 
 	// ----------------------------------
 	// Cloak stuff

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -437,6 +437,7 @@ IMPLEMENT_SERVERCLASS_ST( CFFPlayer, DT_FFPlayer )
 	SendPropBool( SENDINFO( m_bConcussed ) ),
 	SendPropBool( SENDINFO( m_bTranqed ) ),
 	SendPropBool( SENDINFO( m_bSliding ) ),
+	SendPropBool( SENDINFO( m_bIsRampsliding ) ),
 	SendPropEHandle( SENDINFO( m_hActiveSlowfield ) ),
 	SendPropBool( SENDINFO( m_bInfected ) ),
 	SendPropBool( SENDINFO( m_bImmune ) ),
@@ -574,6 +575,8 @@ CFFPlayer::CFFPlayer()
 
 	m_flSlidingTime = 0;		// Not sliding on creation
 	m_bSliding = false;
+
+	m_bIsRampsliding = false;
 
 	m_bGassed = false;
 	m_hGasser = NULL;

--- a/dlls/ff/ff_player.h
+++ b/dlls/ff/ff_player.h
@@ -541,6 +541,12 @@ protected:
 	void StopSliding( void ); // stop the overpressure friction/acceleration effect
 	CNetworkVar( bool, m_bSliding );
 
+public:
+	bool IsRampsliding( void ) const { return m_bIsRampsliding; }
+	void SetRampsliding( bool bIsRampsliding ) { m_bIsRampsliding = bIsRampsliding; }
+protected:
+	CNetworkVar( bool, m_bIsRampsliding );
+
 public:	
 	bool IsInfected( void ) const		{ return m_bInfected; }
 	bool IsImmune( void ) const			{ return m_bImmune; }

--- a/game_shared/ff/ff_gamemovement.cpp
+++ b/game_shared/ff/ff_gamemovement.cpp
@@ -18,7 +18,6 @@
 #include "in_buttons.h"
 #include "movevars_shared.h"
 #include "ff_mapguide.h"
-#include "IEffects.h"
 
 #define	STOP_EPSILON		0.1
 #define	MAX_CLIP_PLANES		5
@@ -958,13 +957,9 @@ void CFFGameMovement::CheckVelocity( void )
 	CFFPlayer *pPlayer = ToFFPlayer( player );
 	if( !pPlayer )
 		return;
-#ifdef CLIENT_DLL
-	if (IsRampSliding(pPlayer))
-	{
-		Vector vecDir = -mv->m_vecVelocity / (mv->m_vecVelocity.LengthSqr() / 1000.0f);
-		g_pEffects->Sparks(pPlayer->GetFeetOrigin() + Vector(random->RandomFloat(-8, 8), random->RandomFloat(-8, 8), 0), 1, 1, &vecDir);
-	}
-#endif
+
+	pPlayer->SetRampsliding(IsRampSliding(pPlayer));
+
 	if( !pPlayer->IsCloaked() )
 		return;
 

--- a/game_shared/ff/ff_gamemovement.cpp
+++ b/game_shared/ff/ff_gamemovement.cpp
@@ -961,7 +961,8 @@ void CFFGameMovement::CheckVelocity( void )
 #ifdef CLIENT_DLL
 	if (IsRampSliding(pPlayer))
 	{
-		g_pEffects->Sparks(pPlayer->GetAbsOrigin());
+		Vector vecDir = -mv->m_vecVelocity / (mv->m_vecVelocity.LengthSqr() / 1000.0f);
+		g_pEffects->Sparks(pPlayer->GetFeetOrigin() + Vector(random->RandomFloat(-8, 8), random->RandomFloat(-8, 8), 0), 1, 1, &vecDir);
 	}
 #endif
 	if( !pPlayer->IsCloaked() )

--- a/game_shared/ff/ff_gamemovement.cpp
+++ b/game_shared/ff/ff_gamemovement.cpp
@@ -18,6 +18,7 @@
 #include "in_buttons.h"
 #include "movevars_shared.h"
 #include "ff_mapguide.h"
+#include "IEffects.h"
 
 #define	STOP_EPSILON		0.1
 #define	MAX_CLIP_PLANES		5
@@ -85,6 +86,7 @@ public:
 	virtual void WalkMove();
 	virtual void AirMove();
 	virtual void Friction();
+	bool IsRampSliding( CFFPlayer *pPlayer );
 
 	CFFGameMovement() {};
 };
@@ -907,6 +909,42 @@ bool CFFGameMovement::CanAccelerate()
 	return true;
 }
 
+bool CFFGameMovement::IsRampSliding( CFFPlayer *pPlayer )
+{
+	if (pPlayer->GetGroundEntity() == NULL)  // Rampsliding occurs when normal ground detection fails
+	{
+		// Take the lateral velocity
+		Vector vecVelocity = mv->m_vecVelocity * Vector(1.0f, 1.0f, 0.0f);
+		float flHorizontalSpeed = vecVelocity.Length();
+
+		if (flHorizontalSpeed > SV_TRIMPTRIGGERSPEED)
+		{
+			trace_t pm;
+
+			Vector vecStart = mv->m_vecAbsOrigin;
+			Vector vecStop = vecStart - Vector(0, 0, 0.1f);
+			
+			TracePlayerBBox(vecStart, vecStop, MASK_PLAYERSOLID, COLLISION_GROUP_PLAYER_MOVEMENT, pm); // but actually you are on the ground
+
+			// Found the floor
+			if(pm.fraction != 1.0f)
+			{
+				if (flHorizontalSpeed > 0)
+					vecVelocity /= flHorizontalSpeed;
+
+				float flDotProduct = DotProduct(vecVelocity, pm.plane.normal);
+				if (flDotProduct < -0.15f) // On an upwards ramp
+				{
+					return true;
+				}
+			}
+		}
+		
+	}
+
+	return false;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Check player velocity & clamp if cloaked
 //-----------------------------------------------------------------------------
@@ -920,7 +958,12 @@ void CFFGameMovement::CheckVelocity( void )
 	CFFPlayer *pPlayer = ToFFPlayer( player );
 	if( !pPlayer )
 		return;
-	
+#ifdef CLIENT_DLL
+	if (IsRampSliding(pPlayer))
+	{
+		g_pEffects->Sparks(pPlayer->GetAbsOrigin());
+	}
+#endif
 	if( !pPlayer->IsCloaked() )
 		return;
 
@@ -933,7 +976,6 @@ void CFFGameMovement::CheckVelocity( void )
 		mv->m_vecVelocity.y *= 0.5f;
 	}
 }
-
 // Expose our interface.
 static CFFGameMovement g_GameMovement;
 IGameMovement *g_pGameMovement = ( IGameMovement * )&g_GameMovement;


### PR DESCRIPTION
Updated duplicate of #48, with some spark improvements and networking

Things that could/should be done:
- [x] Emit something other than sparks (dust) when sliding on grass/dirt/etc. This would probably entail moving all the tracing client-side and removing the networked var
- [x] Add client cvars to toggle rampslide sparks or control their size/etc
