### PR TITLE
Lua: Remove luabind's 'class' implementation because it seems to be broken

### DIFF
--- a/dlls/ff/ff_scriptman.cpp
+++ b/dlls/ff/ff_scriptman.cpp
@@ -177,6 +177,10 @@ void CFFScriptManager::SetupEnvironmentForFF()
 	// initialize luabind
 	luabind::open(L);
 
+	// remove luabind's 'class' implementation because it seems to be broken
+	lua_pushnil(L);
+	lua_setglobal(L, "class");
+
 	// initialize game-specific library
 	CFFLuaLib::Init(L);
 }


### PR DESCRIPTION
It's not used anywhere. See: http://www.rasterbar.com/products/luabind/docs.html#defining-classes-in-lua
