### PR TITLE
Lua: Fix HUD timers' seconds getting truncated in the wrong direction when counting down

### DIFF
--- a/cl_dll/ff/vgui/ff_vgui_timer.cpp
+++ b/cl_dll/ff/vgui/ff_vgui_timer.cpp
@@ -87,12 +87,14 @@ void Timer::UpdateTimer()
 
 	char szText[128];
 
+	int iTimeForDisplay = m_flTimerSpeed > 0 ? floor( m_flTimerValue ) : ceil( m_flTimerValue ); 
+
 	// Timers may be draw in clock style (MM:SS) or just as a counter (n)
 	if (m_bDrawClockStyle)
-		Q_snprintf(szText, 128, "%d:%02d", (int) m_flTimerValue / 60, (int) m_flTimerValue % 60);
+		Q_snprintf(szText, 128, "%d:%02d", iTimeForDisplay / 60, iTimeForDisplay % 60);
 
 	else
-		Q_snprintf(szText, 128, "%d", (int) m_flTimerValue);
+		Q_snprintf(szText, 128, "%d", iTimeForDisplay);
 
 	SetText(szText);
 }


### PR DESCRIPTION
- Was causing 0.9999 seconds left to show as 0
- Timers counting up still have the same behavior as before (0.9999 seconds will show as 0)
- Potentially obsoletes #121
