### PR TITLE
Lua: Add Luabind's class_info function

### DIFF
--- a/dlls/ff/ff_scriptman.cpp
+++ b/dlls/ff/ff_scriptman.cpp
@@ -28,6 +28,7 @@ extern "C"
 
 // luabind
 #include "luabind/luabind.hpp"
+#include "luabind/class_info.hpp"
 #include "luabind/object.hpp"
 #include "luabind/iterator_policy.hpp"
 
@@ -176,6 +177,9 @@ void CFFScriptManager::SetupEnvironmentForFF()
 
 	// initialize luabind
 	luabind::open(L);
+
+	// add class_info to the environment
+	luabind::bind_class_info(L);
 
 	// remove luabind's 'class' implementation because it seems to be broken
 	lua_pushnil(L);


### PR DESCRIPTION
See http://halmd.org/develop/luabind.html#debugging-c-types-with-class-info

When called on a luabind userdata object, it returns an object with the following properties:
- `name`: The Luabind-exposed name (for example: [the CFFPlayer class would have the name "Player"](https://github.com/fortressforever/fortressforever/blob/beta/dlls/ff/ff_lualib_player.cpp#L55))
- `methods`: A table of methodname -> function pairs
- `attributes`: An array-like table of something (not actually sure). Maybe fields?

Note that our version of Luabind will crash if class_info is called on non-userdata objects (see https://github.com/luabind/luabind/commit/2c6c9054e3f9ae00498fc2b56331a17b590ab74e), but this can easily be fixed through Lua (will submit a PR for that in a bit).
