### PR TITLE
Fix crosshair dropdown using # as a spacer character

### DIFF
--- a/cl_dll/ff/vgui/ff_crosshairoptions.cpp
+++ b/cl_dll/ff/vgui/ff_crosshairoptions.cpp
@@ -130,7 +130,7 @@ CFFCrosshairOptions::CFFCrosshairOptions(Panel *parent, char const *panelName) :
 	{
 		KeyValues *kv = new KeyValues("W");
 		kv->SetString("wpid", s_WeaponAliasInfo[i]);
-		m_pCrosshairComboBox->AddItem(VarArgs("#%s", s_WeaponAliasInfo[i]), kv);
+		m_pCrosshairComboBox->AddItem(VarArgs("  %s", s_WeaponAliasInfo[i]), kv);
 		kv->deleteThis();
 	}
 


### PR DESCRIPTION
- Use two actual spaces instead

Closes #142
