### PR TITLE
Fix schedule/timer/menuman memory leak

### DIFF
--- a/dlls/ff/ff_menuman.cpp
+++ b/dlls/ff/ff_menuman.cpp
@@ -333,7 +333,10 @@ void CFFLuaMenuManager::RemoveLuaMenu(const char* szMenuName)
 	// remove the schedule from the list
 	unsigned short it = m_menus.Find(id);
 	if(m_menus.IsValidIndex(it))
+	{
+		delete m_menus[it];
 		m_menus.RemoveAt(it);
+	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -417,6 +420,13 @@ void CFFLuaMenuManager::PlayerMenuExpired(const char *szMenuName)
 /////////////////////////////////////////////////////////////////////////////
 void CFFLuaMenuManager::Shutdown()
 {
+	unsigned short i = m_menus.FirstInorder();
+	while ( i != m_menus.InvalidIndex() )
+	{
+		delete m_menus[i];
+		i = m_menus.NextInorder( i );
+	}
+
 	m_menus.RemoveAll();
 }
 

--- a/dlls/ff/ff_scheduleman.cpp
+++ b/dlls/ff/ff_scheduleman.cpp
@@ -208,7 +208,6 @@ CFFScheduleManager::CFFScheduleManager()
 /////////////////////////////////////////////////////////////////////////////
 CFFScheduleManager::~CFFScheduleManager()
 {
-
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -393,12 +392,22 @@ void CFFScheduleManager::RemoveSchedule(const char* szScheduleName)
 	// remove the schedule from the list
 	unsigned short it = m_schedules.Find(id);
 	if(m_schedules.IsValidIndex(it))
+	{
+		delete m_schedules[it];
 		m_schedules.RemoveAt(it);
+	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
 void CFFScheduleManager::Shutdown()
 {
+	unsigned short i = m_schedules.FirstInorder();
+	while ( i != m_schedules.InvalidIndex() )
+	{
+		delete m_schedules[i];
+		i = m_schedules.NextInorder( i );
+	}
+
 	m_schedules.RemoveAll();
 }
 
@@ -430,7 +439,10 @@ void CFFScheduleManager::Update()
 					return;
 
 				if (pCallbackCheck->IsComplete())
+				{
+					delete m_schedules[itCheck];
 					m_schedules.RemoveAt(itCheck);
+				}
 			}
 		}
 		else

--- a/dlls/ff/ff_timerman.cpp
+++ b/dlls/ff/ff_timerman.cpp
@@ -109,12 +109,22 @@ void CFFTimerManager::RemoveTimer(const char* szTimerName)
 	// remove the timer from the list
 	unsigned short it = m_timers.Find(id);
 	if(m_timers.IsValidIndex(it))
+	{
+		delete m_timers[it];
 		m_timers.RemoveAt(it);
+	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
 void CFFTimerManager::Shutdown()
 {
+	unsigned short i = m_timers.FirstInorder();
+	while ( i != m_timers.InvalidIndex() )
+	{
+		delete m_timers[i];
+		i = m_timers.NextInorder( i );
+	}
+
 	m_timers.RemoveAll();
 }
 
@@ -133,6 +143,7 @@ void CFFTimerManager::Update()
 			// remove and cleanup the timer
 			unsigned int itDeleteMe = it;
 			it = m_timers.NextInorder(it);
+			delete m_timers[itDeleteMe];
 			m_timers.RemoveAt(itDeleteMe);
 		}
 		else


### PR DESCRIPTION
24f8f8c6f2873dd0827411648aa6ee74478ef501 removed the deletes from CFFScheduleManager and claimed that CUtlMap's remove functions do the deletion, but I can find no evidence for that being the case

The only other instance of a dynamically allocated pointer being stored as the value of a CUtlMap is CPhysSaveRestoreBlockHandler::m_QueuedRestores, which does its own deletions. This commit mirrors CPhysSaveRestoreBlockHandler's logic exactly.
