### PR TITLE
Enable hud_speedometer by default

### DIFF
--- a/cl_dll/ff/ff_hud_speedometer.cpp
+++ b/cl_dll/ff/ff_hud_speedometer.cpp
@@ -35,7 +35,7 @@
 
 using namespace vgui;
 
-static ConVar hud_speedometer( "hud_speedometer", "0", FCVAR_ARCHIVE, "Toggle speedometer. Disclaimer: We are not responsible if you get a ticket.");
+static ConVar hud_speedometer( "hud_speedometer", "1", FCVAR_ARCHIVE, "Toggle speedometer. Disclaimer: We are not responsible if you get a ticket.");
 static ConVar hud_speedometer_avg( "hud_speedometer_avg", "0", FCVAR_ARCHIVE, "Toggle average speedometer.");
 // ELMO *** 
 static ConVar hud_speedometer_color( "hud_speedometer_color", "2", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);


### PR DESCRIPTION
> 10:51 PM - oats: squeek
> 10:51 PM - oats: make hud_speedometer 1
> 10:51 PM - oats: default
> 10:51 PM - oats: ty
> 10:51 PM - squeek.: ok
> 10:52 PM - oats: its more intuitive
> 10:52 PM - oats: every noob ive trained
> 10:52 PM - squeek.: yeah
> 10:52 PM - oats: they turn it on
> 10:52 PM - oats: and then i notice them
> 10:52 PM - oats: they notice bhopping down slopes = speed boost
> 10:52 PM - oats: i think it would fix the problem people have with the FF training as well
> 10:52 PM - oats: during that bhop section
> 10:52 PM - oats: if they see how changing their mouse movement changes how they gain speed
> 10:52 PM - oats: they can get bhop ezier
> 10:52 PM - oats: overall thats my case pls do
> 10:52 PM - oats: ty
