### PR TITLE
Remove encryption key so .ctx player/weapon scripts don't get loaded

### DIFF
--- a/game_shared/gamerules.h
+++ b/game_shared/gamerules.h
@@ -143,7 +143,7 @@ public:
 // Functions to verify the single/multiplayer status of a game
 	virtual bool IsMultiplayer( void ) = 0;// is this a multiplayer game? (either coop or deathmatch)
 
-	virtual const unsigned char *GetEncryptionKey() { return (const unsigned char *)"saxEWr5v"; }
+	virtual const unsigned char *GetEncryptionKey() { return NULL; }
 #ifdef CLIENT_DLL
 
 	// --> Mirv: Clientside rules


### PR DESCRIPTION
- Makes it so that .txt files are prioritized over .ctx, so that if the pre-Greenlight encrypted scripts still exist on a server install, they get ignored
