### PR TITLE
Lua: Add get equivalents of exposed team set functions

### DIFF
--- a/dlls/ff/ff_lualib_globals.cpp
+++ b/dlls/ff/ff_lualib_globals.cpp
@@ -551,9 +551,9 @@ namespace FFLib
 
 	CFFTeam* GetTeam(int teamId)
 	{
-		if( teamId < TEAM_BLUE )
+		if( teamId <= TEAM_INVALID )
 			return NULL;
-		if( teamId > TEAM_GREEN )
+		if( teamId >= TEAM_COUNT )
 			return NULL;
 
 		return dynamic_cast<CFFTeam*>(g_Teams[teamId]);

--- a/dlls/ff/ff_lualib_team.cpp
+++ b/dlls/ff/ff_lualib_team.cpp
@@ -39,19 +39,18 @@ namespace FFLib
 	luabind::adl::object GetAllies(CFFTeam *pTeam)
 	{
 		luabind::adl::object luatblAllies = luabind::newtable(_scriptman.GetLuaState());
-		if (pTeam)
+
+		int iTableKey = 1;
+		int alliesMask = pTeam->GetAllies();
+		for (int teamId = TEAM_UNASSIGNED; teamId < TEAM_COUNT; teamId++)
 		{
-			int iTableKey = 1;
-			int alliesMask = pTeam->GetAllies();
-			for (int teamId = TEAM_UNASSIGNED; teamId < TEAM_COUNT; teamId++)
-			{
-				if (alliesMask & (1<<teamId))
-				{
-					CFFTeam *pAlliedTeam = dynamic_cast<CFFTeam*>(g_Teams[teamId]);
-					luatblAllies[iTableKey++] = luabind::adl::object(_scriptman.GetLuaState(), pAlliedTeam);
-				}
-			}
+			if (!(alliesMask & (1<<teamId)))
+				continue;
+
+			CFFTeam *pAlliedTeam = dynamic_cast<CFFTeam*>(g_Teams[teamId]);
+			luatblAllies[iTableKey++] = luabind::adl::object(_scriptman.GetLuaState(), pAlliedTeam);
 		}
+
 		return luatblAllies;
 	}
 };


### PR DESCRIPTION
Adds functions:
 team:GetAllies() // returns a table of the team's allies (table of CFFTeam objects)
 team:GetPlayerLimit() // returns the team's player limit
 team:GetClassLimit(int class_id) // returns the team's class limit for the given class

Also allows GetTeam to return the unassigned/spectator teams.

Contributes towards #186 

Tested using the following code:

``` lua
assert_equal(GetTeam(Team.kUnassigned) ~= nil, true, "GetTeam should return non-nil for unassigned")
assert_equal(GetTeam(Team.kSpectator) ~= nil, true, "GetTeam should return non-nil for spec")

local red_team = GetTeam(Team.kRed)
local green_team = GetTeam(Team.kGreen)

assert_equal(red_team:GetPlayerLimit(), 0, "Red should have no player limit")
assert_equal(green_team:GetPlayerLimit(), -1, "Green should have -1 player limit")

assert_equal(red_team:GetClassLimit(Player.kScout), 0, "Red scout should have no class limit")
assert_equal(red_team:GetClassLimit(Player.kCivilian), -1, "Red civ should have -1 class limit")

red_team:ClearAllies()
assert_equal(#red_team:GetAllies(), 0, "Red should have no allies")
red_team:SetAllies(Team.kGreen)
assert_equal(#red_team:GetAllies(), 1, "Red should have 1 ally")
assert_equal(red_team:GetAllies()[1]:GetTeamId(), green_team:GetTeamId(), "Red should be allied with the green team")
red_team:ClearAllies()
assert_equal(#red_team:GetAllies(), 0, "Red should have no allies")
```
