### PR TITLE
Fix explosions going through brushes when directly underneath them

### DIFF
--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -1290,11 +1290,6 @@ ConVar mp_prematch( "mp_prematch",
 		// TFC style falloff please.
 		falloff = 0.5f; // AfterShock: need to change this if you want to have a radius over 2x the damage
 
-		// Always raise by 1.0f
-		// It's so that the grenade isn't in the ground
-		// AfterShock: Isn't this going to raise grenades into the ceiling if they explode there? Shouldnt we be raising off the surface normal instead?
-		vecSrc.z += 1.0f;
-
 		// iterate on all entities in the vicinity.
 		for (CEntitySphereQuery sphere(vecSrc, flRadius); (pEntity = sphere.GetCurrentEntity()) != NULL; sphere.NextEntity()) 
 		{


### PR DESCRIPTION
- The z+1 seems to be carried over from HL1 code but is no longer necessary, and was causing things that explode underneath a brush to be pushed up into the brush and then hit things through the brush. Tested with a double bounced rail explosion (was 100% consistently reproducible).

Shock was right to be worried.
