### PR TITLE
Fix CFFPlayer noisy BodyTarget while crouched

### DIFF
--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -7620,7 +7620,7 @@ Vector CFFPlayer::BodyTarget(const Vector &posSrc, bool bNoisy)
 
 	if (bNoisy)
 	{
-		return GetAbsOrigin() + (Vector(0, 0, 28) * random->RandomFloat(0.5f, 1.1f));
+		return GetAbsOrigin() + (GetViewOffset() * random->RandomFloat(0.5f, 1.1f));
 	}
 	else
 	{


### PR DESCRIPTION
- Was always returning a hardcoded view offset instead of taking crouching into account
- Should make explosions while crouched behave better
