### PR TITLE
Fix explosions doing too much damage to crouched players in certain cases

### DIFF
--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -1333,8 +1333,8 @@ ConVar mp_prematch( "mp_prematch",
 				CFFPlayer *pPlayer = ToFFPlayer(pEntity);
 				float flBodyTargetOffset = vecSpot.z - pPlayer->GetAbsOrigin().z;
 
-                float dH = vecDisplacement.Length2D() - 16.0f;	// Half of model width
-				float dV = fabs(vecDisplacement.z - flBodyTargetOffset) - 36.0f; // Half of model height
+                float dH = vecDisplacement.Length2D() - pPlayer->GetPlayerMaxs().x;	// Half of model width
+				float dV = fabs(vecDisplacement.z - flBodyTargetOffset) - pPlayer->GetPlayerMaxs().z; // Half of model height
 
 				// Inside our model bounds
 				if (dH <= 0.0f && dV <= 0.0f)


### PR DESCRIPTION
- Fixes the hitbox hack always using full height dimensions / ignoring the player being crouched
- Seems to affect things that explode above the player the most, but also affects things like crouched rocket jumping and railgun jumping
- See also #188
