### PR TITLE
Add basic armorstrip convar: mp_friendlyfire_armorstrip

### DIFF
--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -140,6 +140,7 @@ ConVar ffdev_gibdamage("ffdev_gibdamage", "50", FCVAR_FF_FFDEV_REPLICATED, "If a
 #define FFDEV_GIBDAMAGE ffdev_gibdamage.GetFloat()
 
 extern ConVar sv_maxspeed;
+extern ConVar mp_armorstrip;
 
 //ConVar ffdev_spy_cloakfadespeed( "ffdev_spy_cloaktime", "1", FCVAR_REPLICATED, "Time it takes to cloak (fade out to cloak)" );
 #define FFDEV_SPY_CLOAKFADESPEED 1.0f
@@ -5420,6 +5421,12 @@ int CFFPlayer::OnTakeDamage(const CTakeDamageInfo &inputInfo)
 		float fArmorDamage = fFullDamage * (((float)m_iArmorType) / 10.0f); //AfterShock: changing int to float e.g. armor type 8 means 0.8 i.e. 80% damage absorbed by armor
 		float fHealthDamage = fFullDamage - fArmorDamage;
 		float fArmorLeft = (float) m_iArmor;
+		bool shouldArmorstrip = mp_armorstrip.GetFloat() > 0 && g_pGameRules->PlayerRelationship( this, info.GetAttacker() ) == GR_TEAMMATE;
+
+		if (shouldArmorstrip)
+		{
+			fArmorDamage *= mp_armorstrip.GetFloat();
+		}
 
 		// if the armor damage is greater than the amount of armor remaining, apply the excess straight to health
 		if(fArmorDamage > fArmorLeft)
@@ -5431,6 +5438,11 @@ int CFFPlayer::OnTakeDamage(const CTakeDamageInfo &inputInfo)
 		else
 		{
 			m_iArmor -= (int) fArmorDamage;
+		}
+
+		if (shouldArmorstrip)
+		{
+			fHealthDamage = 0;
 		}
 
 		// Set armor lost for hud "damage" message

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -140,7 +140,7 @@ ConVar ffdev_gibdamage("ffdev_gibdamage", "50", FCVAR_FF_FFDEV_REPLICATED, "If a
 #define FFDEV_GIBDAMAGE ffdev_gibdamage.GetFloat()
 
 extern ConVar sv_maxspeed;
-extern ConVar mp_armorstrip;
+extern ConVar mp_friendlyfire_armorstrip;
 
 //ConVar ffdev_spy_cloakfadespeed( "ffdev_spy_cloaktime", "1", FCVAR_REPLICATED, "Time it takes to cloak (fade out to cloak)" );
 #define FFDEV_SPY_CLOAKFADESPEED 1.0f
@@ -5421,11 +5421,11 @@ int CFFPlayer::OnTakeDamage(const CTakeDamageInfo &inputInfo)
 		float fArmorDamage = fFullDamage * (((float)m_iArmorType) / 10.0f); //AfterShock: changing int to float e.g. armor type 8 means 0.8 i.e. 80% damage absorbed by armor
 		float fHealthDamage = fFullDamage - fArmorDamage;
 		float fArmorLeft = (float) m_iArmor;
-		bool shouldArmorstrip = mp_armorstrip.GetFloat() > 0 && g_pGameRules->PlayerRelationship( this, info.GetAttacker() ) == GR_TEAMMATE;
+		bool shouldArmorstrip = mp_friendlyfire_armorstrip.GetFloat() > 0 && g_pGameRules->PlayerRelationship( this, info.GetAttacker() ) == GR_TEAMMATE;
 
 		if (shouldArmorstrip)
 		{
-			fArmorDamage *= mp_armorstrip.GetFloat();
+			fArmorDamage *= mp_friendlyfire_armorstrip.GetFloat();
 		}
 
 		// if the armor damage is greater than the amount of armor remaining, apply the excess straight to health

--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -181,10 +181,10 @@ ConVar mp_prematch( "mp_prematch",
 					FCVAR_NOTIFY|FCVAR_REPLICATED,
 					"delay before game starts" );
 
-ConVar mp_armorstrip( "mp_armorstrip",
+ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 					"0",
 					FCVAR_NOTIFY|FCVAR_REPLICATED,
-					"If > 0, only deals armor damage to teammates. The armor damage is multiplied by the value of the cvar (mp_armorstrip 0.5 means half damage). Requires mp_friendlyfire 1" );
+					"If > 0, only deals armor damage to teammates. The armor damage is multiplied by the value of the cvar (mp_friendlyfire_armorstrip 0.5 means half damage). Requires mp_friendlyfire 1" );
 
 #ifdef CLIENT_DLL
 	void RecvProxy_FFGameRules( const RecvProp *pProp, void **pOut, void *pData, int objectID )

--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -181,6 +181,11 @@ ConVar mp_prematch( "mp_prematch",
 					FCVAR_NOTIFY|FCVAR_REPLICATED,
 					"delay before game starts" );
 
+ConVar mp_armorstrip( "mp_armorstrip",
+					"0",
+					FCVAR_NOTIFY|FCVAR_REPLICATED,
+					"If > 0, only deals armor damage to teammates. The armor damage is multiplied by the value of the cvar (mp_armorstrip 0.5 means half damage). Requires mp_friendlyfire 1" );
+
 #ifdef CLIENT_DLL
 	void RecvProxy_FFGameRules( const RecvProp *pProp, void **pOut, void *pData, int objectID )
 	{


### PR DESCRIPTION
From the cvar description:
  If > 0, only deals armor damage to teammates. The armor damage is multiplied by the value of the cvar (mp_friendlyfire_armorstrip 0.5 means half damage). Requires mp_friendlyfire 1

Contributes towards #50 (or closes it if we don't want to implement all of the features of mp_teamplay)
