### PR TITLE
Revert "Fix schedule/timer/menuman memory leak"

### DIFF
--- a/dlls/ff/ff_menuman.cpp
+++ b/dlls/ff/ff_menuman.cpp
@@ -333,10 +333,7 @@ void CFFLuaMenuManager::RemoveLuaMenu(const char* szMenuName)
 	// remove the schedule from the list
 	unsigned short it = m_menus.Find(id);
 	if(m_menus.IsValidIndex(it))
-	{
-		delete m_menus[it];
 		m_menus.RemoveAt(it);
-	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -420,13 +417,6 @@ void CFFLuaMenuManager::PlayerMenuExpired(const char *szMenuName)
 /////////////////////////////////////////////////////////////////////////////
 void CFFLuaMenuManager::Shutdown()
 {
-	unsigned short i = m_menus.FirstInorder();
-	while ( i != m_menus.InvalidIndex() )
-	{
-		delete m_menus[i];
-		i = m_menus.NextInorder( i );
-	}
-
 	m_menus.RemoveAll();
 }
 

--- a/dlls/ff/ff_scheduleman.cpp
+++ b/dlls/ff/ff_scheduleman.cpp
@@ -208,6 +208,7 @@ CFFScheduleManager::CFFScheduleManager()
 /////////////////////////////////////////////////////////////////////////////
 CFFScheduleManager::~CFFScheduleManager()
 {
+
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -392,22 +393,12 @@ void CFFScheduleManager::RemoveSchedule(const char* szScheduleName)
 	// remove the schedule from the list
 	unsigned short it = m_schedules.Find(id);
 	if(m_schedules.IsValidIndex(it))
-	{
-		delete m_schedules[it];
 		m_schedules.RemoveAt(it);
-	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
 void CFFScheduleManager::Shutdown()
 {
-	unsigned short i = m_schedules.FirstInorder();
-	while ( i != m_schedules.InvalidIndex() )
-	{
-		delete m_schedules[i];
-		i = m_schedules.NextInorder( i );
-	}
-
 	m_schedules.RemoveAll();
 }
 
@@ -439,10 +430,7 @@ void CFFScheduleManager::Update()
 					return;
 
 				if (pCallbackCheck->IsComplete())
-				{
-					delete m_schedules[itCheck];
 					m_schedules.RemoveAt(itCheck);
-				}
 			}
 		}
 		else

--- a/dlls/ff/ff_timerman.cpp
+++ b/dlls/ff/ff_timerman.cpp
@@ -109,22 +109,12 @@ void CFFTimerManager::RemoveTimer(const char* szTimerName)
 	// remove the timer from the list
 	unsigned short it = m_timers.Find(id);
 	if(m_timers.IsValidIndex(it))
-	{
-		delete m_timers[it];
 		m_timers.RemoveAt(it);
-	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
 void CFFTimerManager::Shutdown()
 {
-	unsigned short i = m_timers.FirstInorder();
-	while ( i != m_timers.InvalidIndex() )
-	{
-		delete m_timers[i];
-		i = m_timers.NextInorder( i );
-	}
-
 	m_timers.RemoveAll();
 }
 
@@ -143,7 +133,6 @@ void CFFTimerManager::Update()
 			// remove and cleanup the timer
 			unsigned int itDeleteMe = it;
 			it = m_timers.NextInorder(it);
-			delete m_timers[itDeleteMe];
 			m_timers.RemoveAt(itDeleteMe);
 		}
 		else


### PR DESCRIPTION
Reverts fortressforever/fortressforever#173

> I'm going to revert this because I've been getting some mysterious crashes while changing map that seem to be related to Lua shutting down and freeing memory. Reverting this locally seemed to fix those crashes as well.
> 
> I guess I shouldn't try to fix what I'm not totally sure is broken.

Didn't know it'd open a new PR.
