### PR TITLE
Add global callbacks intermission() and restartround()

### DIFF
--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -630,7 +630,12 @@ ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 		// absolutely everything - scores, players, entities, etc.		
 		if( bFullReset )
 		{
-			// TODO: Do stuff!
+			// give lua a chance to prepare for the restart
+			if (_scriptman.GetLuaState() != NULL)
+			{
+				CFFLuaSC hRestartRound;
+				_scriptman.RunPredicates_LUA(NULL, &hRestartRound, "restartround");
+			}
 
 			m_flIntermissionEndTime = 0.f;
 
@@ -1034,6 +1039,17 @@ ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 		{
 			GoToIntermission();
 		}
+	}
+
+	void CFFGameRules::GoToIntermission()
+	{
+		if ( g_fGameOver )
+			return;
+
+		BaseClass::GoToIntermission();
+
+		CFFLuaSC hIntermission;
+		_scriptman.RunPredicates_LUA(NULL, &hIntermission, "intermission");
 	}
 
 	//-----------------------------------------------------------------------------

--- a/game_shared/ff/ff_gamerules.h
+++ b/game_shared/ff/ff_gamerules.h
@@ -150,6 +150,7 @@ public:
 	virtual void	RestartRound( void );
 
 	virtual void	ResetUsingCriteria( bool *pbFlags, int iTeam = TEAM_UNASSIGNED, CFFPlayer *pFFPlayer = NULL, bool bFullReset = false );
+	virtual void	GoToIntermission( void );
 
 	virtual void	UpdateSpawnPoints();
 	CUtlVector<CBaseEntity*> m_SpawnPoints;


### PR DESCRIPTION
- intermission() is called when intermission starts
- restartround() is called right before the round is restarted, to allow for Lua to persist data before the Lua environment is destroyed and re-created
