### PR TITLE
Add splashes for entities/players entering water

### DIFF
--- a/game_shared/ff/ff_projectile_base.cpp
+++ b/game_shared/ff/ff_projectile_base.cpp
@@ -18,6 +18,7 @@
 	#include "ff_player.h"
 	#include "soundent.h"
 	#include "util.h"
+	#include "te_effect_dispatch.h"
 #else
 	#include "c_ff_player.h"
 	#include "iinput.h"
@@ -213,6 +214,20 @@ END_NETWORK_TABLE()
 		if (GetAbsOrigin().z <= MIN_COORD_INTEGER) return false;
 
 		return true;
+	}
+
+	/** Override CBaseEntity::Splash to spawn splash effects
+		when the projectile enters water
+	*/
+	void CFFProjectileBase::Splash()
+	{
+		CEffectData	data;
+
+		data.m_fFlags  = 0;
+		data.m_vOrigin = GetAbsOrigin();
+		data.m_flScale = 8.0f;
+
+		DispatchEffect("watersplash", data);
 	}
 #endif
 

--- a/game_shared/ff/ff_projectile_base.h
+++ b/game_shared/ff/ff_projectile_base.h
@@ -82,6 +82,9 @@ private:
 	void SetupInitialTransmittedVelocity(const Vector &velocity);
 	int TakeEmp();
 	virtual bool IsInWorld( void ) const;
+	
+	// from CBaseEntity
+	virtual void Splash();
 
 #endif
 


### PR DESCRIPTION
I'm pushing any WIP stuff I had sitting on my computer just in case anyone felt like picking it up where I left off. This almost works, but it breaks if the projectile is spawned under water (it splashes like crazy until it surfaces IIRC).

---

See #100
