### PR TITLE
Wrenching a dispenser now makes it recharge faster

### DIFF
--- a/game_shared/ff/ff_weapon_spanner.cpp
+++ b/game_shared/ff/ff_weapon_spanner.cpp
@@ -203,7 +203,7 @@ void CFFWeaponSpanner::Hit(trace_t &traceHit, Activity nHitActivity)
 					int iCells = min( 5, pDispenser->NeedsCells() );
 					int iShells = min( 5, pDispenser->NeedsShells() );
 					int iNails = min( 5, pDispenser->NeedsNails() );
-					int iRockets = min( 5, pDispenser->NeedsRockets() );
+					int iRockets = min( 3, pDispenser->NeedsRockets() );
 
 					// If we give it anything, play a special sound. Pun intended.
 					if( ( iCells > 0 ) || ( iShells > 0 ) || ( iNails > 0 ) || ( iRockets > 0 ) )

--- a/game_shared/ff/ff_weapon_spanner.cpp
+++ b/game_shared/ff/ff_weapon_spanner.cpp
@@ -200,10 +200,10 @@ void CFFWeaponSpanner::Hit(trace_t &traceHit, Activity nHitActivity)
 				else
 				{
 					// On subsequent clangs, we gotta give it ammo and stuff!
-					int iCells = min( min( 40, pPlayer->GetAmmoCount( AMMO_CELLS ) ), pDispenser->NeedsCells() );
-					int iShells = min( min( 40, pPlayer->GetAmmoCount( AMMO_SHELLS ) ), pDispenser->NeedsShells() );
-					int iNails = min( min( 30, pPlayer->GetAmmoCount( AMMO_NAILS ) ), pDispenser->NeedsNails() );
-					int iRockets = min( min( 10, pPlayer->GetAmmoCount( AMMO_ROCKETS ) ), pDispenser->NeedsRockets() );
+					int iCells = min( 5, pDispenser->NeedsCells() );
+					int iShells = min( 5, pDispenser->NeedsShells() );
+					int iNails = min( 5, pDispenser->NeedsNails() );
+					int iRockets = min( 5, pDispenser->NeedsRockets() );
 
 					// If we give it anything, play a special sound. Pun intended.
 					if( ( iCells > 0 ) || ( iShells > 0 ) || ( iNails > 0 ) || ( iRockets > 0 ) )
@@ -212,10 +212,10 @@ void CFFWeaponSpanner::Hit(trace_t &traceHit, Activity nHitActivity)
 #ifdef GAME_DLL
 					pDispenser->AddAmmo( 0, iCells, iShells, iNails, iRockets );
 
-					pPlayer->RemoveAmmo( iCells, AMMO_CELLS );
-					pPlayer->RemoveAmmo( iShells, AMMO_SHELLS );
-					pPlayer->RemoveAmmo( iNails, AMMO_NAILS );
-					pPlayer->RemoveAmmo( iRockets, AMMO_ROCKETS );
+					//pPlayer->RemoveAmmo( iCells, AMMO_CELLS );
+					//pPlayer->RemoveAmmo( iShells, AMMO_SHELLS );
+					//pPlayer->RemoveAmmo( iNails, AMMO_NAILS );
+					//pPlayer->RemoveAmmo( iRockets, AMMO_ROCKETS );
 #endif
 				}
 


### PR DESCRIPTION
Rather than giving it ammo.

Why?
- Make cell generation more dynamic - the engineer does not simply wait for the dispenser to fill up, he can choose to increase it's recharge speed in return for time
- (minor) Engineer no longer accidentally adds ammo to a dispenser after repairing it
- engineer can now choose whether to use the railgun, collecting bags, or hitting the dispenser as possible cell generation tactics.

Currently it adds 5 cells per whack
