### PR TITLE
Fix cl_spawnweapon_ cvars when set to the last weapon slot

### DIFF
--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -1585,7 +1585,7 @@ void CFFPlayer::Spawn( void )
 		CBaseCombatWeapon *pSpawnWeapon = Weapon_OwnsThisType(weaponSpawn);
 		if(pSpawnWpn && pSpawnWeapon)
 		{
-			if(Weapon_Switch(pSpawnWeapon))
+			if(pSpawnWeapon == GetActiveWeapon() || Weapon_Switch(pSpawnWeapon))
 				break;
 		}
 


### PR DESCRIPTION
- Fixes #222
