### PR TITLE
Add basic support for free-for-all teams

### DIFF
--- a/cl_dll/ff/c_ff_team.cpp
+++ b/cl_dll/ff/c_ff_team.cpp
@@ -21,6 +21,7 @@ IMPLEMENT_CLIENTCLASS_DT(C_FFTeam, DT_FFTeam, CFFTeam)
 	// --> Mirv: Some limits that the client needs to know about for the menu
 	RecvPropInt( RECVINFO( m_iAllies ) ),
 	RecvPropInt( RECVINFO( m_iMaxPlayers ) ),
+	RecvPropBool( RECVINFO( m_bFFA ) ),
 	RecvPropArray3( RECVINFO_ARRAY(m_iClasses), RecvPropInt( RECVINFO(m_iClasses[0]))),
 	// <-- Mirv: Some limits that the client needs to know about for the menu
 END_RECV_TABLE()

--- a/cl_dll/ff/c_ff_team.h
+++ b/cl_dll/ff/c_ff_team.h
@@ -38,11 +38,15 @@ public:
 	virtual int		Get_Teams( void );
 	virtual int		GetAllies( void );
 
+	bool IsFFA() { return m_bFFA; };
+	void SetFFA( bool bFFA ) { m_bFFA = bFFA; };
+
 private:
 
 	int		m_iClasses[12];
 	int		m_iMaxPlayers;
 	int		m_iAllies;
+	bool	m_bFFA;
 	// <-- Mirv: Menus need to know limits
 
 };

--- a/dlls/ff/ff_lualib_team.cpp
+++ b/dlls/ff/ff_lualib_team.cpp
@@ -90,6 +90,8 @@ void CFFLuaLib::InitTeam(lua_State* L)
 			.def("GetClassLimit",		&CFFTeam::GetClassLimit)
 			.def("SetPlayerLimit",		&CFFTeam::SetTeamLimits)
 			.def("GetPlayerLimit",		&CFFTeam::GetTeamLimits)
+			.def("IsFFA",				&CFFTeam::IsFFA)
+			.def("SetFFA",				&CFFTeam::SetFFA)
 			.enum_("TeamId")
 			[
 				value("kUnassigned",	TEAM_UNASSIGNED),

--- a/dlls/ff/ff_team.cpp
+++ b/dlls/ff/ff_team.cpp
@@ -17,6 +17,7 @@ IMPLEMENT_SERVERCLASS_ST(CFFTeam, DT_FFTeam)
 	// --> Mirv: Some limits that the client needs to know about for the menu
 	SendPropInt( SENDINFO( m_iAllies ) ), //AfterShock: this has a flag for each team
 	SendPropInt( SENDINFO( m_iMaxPlayers ) ),
+	SendPropBool( SENDINFO( m_bFFA ) ),
 	SendPropArray3( SENDINFO_ARRAY3(m_iClasses), SendPropInt( SENDINFO_ARRAY(m_iClasses), 4 ) ),
 	
 	// <-- Mirv: Some limits that the client needs to know about for the menu

--- a/dlls/ff/ff_team.h
+++ b/dlls/ff/ff_team.h
@@ -38,6 +38,9 @@ public:
 	int m_iClassesMap[12];					// this is just the map limits
 
 	CNetworkVar( int, m_iMaxPlayers );
+
+private:
+	CNetworkVar( bool, m_bFFA );
 	
 
 public:
@@ -53,6 +56,9 @@ public:
 	int GetAllies( void );
 
 	void UpdateLimits( void );
+
+	bool IsFFA() { return m_bFFA; };
+	void SetFFA( bool bFFA ) { m_bFFA = bFFA; };
 	// <-- Mirv: Team classes available and allies
 };
 

--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -2246,9 +2246,15 @@ int CFFGameRules::PlayerRelationship( CBaseEntity *pPlayer, CBaseEntity *pTarget
 {
 	if( !pPlayer || !pTarget )
 		return GR_NOTTEAMMATE;
-	
-	if( pPlayer->GetTeamNumber() == pTarget->GetTeamNumber() )
+
+	if( pPlayer == pTarget )
 		return GR_TEAMMATE;
+
+	if( pPlayer->GetTeamNumber() == pTarget->GetTeamNumber() )
+	{
+		CFFTeam *pTeam = ( CFFTeam * )GetGlobalTeam( pPlayer->GetTeamNumber() );
+		return pTeam->IsFFA() ? GR_NOTTEAMMATE : GR_TEAMMATE;
+	}
 
 	if( pPlayer->IsPlayer() && pTarget->IsPlayer() )
 	{
@@ -2301,7 +2307,10 @@ int CFFGameRules::IsTeam1AlliedToTeam2( int iTeam1, int iTeam2 )
 
 	// Same team, but still the result we're looking for
 	if( iTeam1 == iTeam2 )
-		return GR_TEAMMATE;
+	{
+		CFFTeam *pTeam = ( CFFTeam * )GetGlobalTeam( iTeam1 );
+		return pTeam->IsFFA() ? GR_NOTTEAMMATE : GR_TEAMMATE;
+	}
 	else
 	{
 		// Use mirv's allies stuff...


### PR DESCRIPTION
- Lua can set a team as a free-for-all team by doing `GetTeam(Team.kBlue):SetFFA(true)`
- Closes #49
- Needs a base_respawnturret.lua change to stop respawn turrets joining in on the free-for-all (fortressforever/fortressforever-scripts#56)

Added Lua functions:
- team:IsFFA()
- team:SetFFA(boolean)
