### PR TITLE
Improve Lua angle/vectors a bit

### DIFF
--- a/dlls/ff/ff_lualib_player.cpp
+++ b/dlls/ff/ff_lualib_player.cpp
@@ -165,6 +165,7 @@ void CFFLuaLib::InitPlayer(lua_State* L)
 			.def("GetDispenser",		&CFFPlayer::GetDispenser)
 			.def("GetDetpack",			&CFFPlayer::GetDetpack)
 			.def("GetJumpPad",			&CFFPlayer::GetManCannon)
+			.def("GetEyeAngles",		&CFFPlayer::EyeAngles)
 
 			.enum_("ClassId")
 			[


### PR DESCRIPTION
- Add player:GetEyeAngles()
- Add __tostring() implementations for Vector and QAngle classes
- Convert VectorAngles and AngleVectors to use Lua-style return values rather than C++ style pass-by-reference parameters. Example usage of the new functions:
  
  local eye_angles = player:GetEyeAngles()
  local forward, right, up = AngleVectors(eye_angles)
  local angles = VectorAngles(forward)
  assert(angles == eye_angles)

Note: This change is NOT backwards compatible, but as far as I can tell, no existing Lua scripts use either VectorAngles or AngleVectors currently (at least none that I have downloaded on my computer)
