### PR TITLE
Fix performance issues with SpriteTrails when their parent teleports

### DIFF
--- a/game_shared/SpriteTrail.h
+++ b/game_shared/SpriteTrail.h
@@ -84,6 +84,7 @@ private:
 	void	ComputeScreenPosition( Vector *pScreenPos );
 	void	ConvertSkybox();
 	void	UpdateBoundingBox( void );
+	bool	IsEnabledByClient();
 
 	TrailPoint_t	m_vecSteps[MAX_SPRITE_TRAIL_POINTS];
 	int	m_nFirstStep;


### PR DESCRIPTION
- Fixes stutter when the flag returns after it is capped (closes #280)
- Adds cvar cl_spritetrail_maxlength that controls the max length of a sprite trail (once exceeded, the trail will start over from its parent's current origin)
- Makes it so trails are not calculated at all client-side if they are disabled by their respective cvars
