### PR TITLE
Fix local weapon sounds (like deploy sounds) playing twice on high ping

### DIFF
--- a/game_shared/ff/ff_weapon_base.cpp
+++ b/game_shared/ff/ff_weapon_base.cpp
@@ -179,6 +179,7 @@ void CFFWeaponBase::WeaponSound(WeaponSound_t sound_type, float soundtime /* = 0
 //----------------------------------------------------------------------------
 void CFFWeaponBase::WeaponSoundLocal( WeaponSound_t sound_type, float soundtime )
 {
+#ifdef CLIENT_DLL 
 	// If we have some sounds from the weapon classname.txt file, play a random one of them
 	const char *shootsound = GetWpnData().aShootSounds[ sound_type ];
 	if( !shootsound || !shootsound[0] )
@@ -191,8 +192,7 @@ void CFFWeaponBase::WeaponSoundLocal( WeaponSound_t sound_type, float soundtime 
 
 	CSingleUserRecipientFilter filter( GetPlayerOwner() );
 
-#ifdef CLIENT_DLL 
-	if( GetPlayerOwner() == C_FFPlayer::GetLocalFFPlayer() )
+	if( GetPlayerOwner() == C_FFPlayer::GetLocalFFPlayerOrObserverTarget() )
 	{
 		// Not sure why we're checking tempents... but we did it above^^
 		if( !te->CanPredict() )
@@ -203,9 +203,7 @@ void CFFWeaponBase::WeaponSoundLocal( WeaponSound_t sound_type, float soundtime 
 
 		EmitSound( filter, GetPlayerOwner()->entindex(), shootsound, NULL, soundtime );
 	}
-#else
-	EmitSound( filter, GetPlayerOwner()->entindex(), shootsound, NULL, soundtime );
-#endif	
+#endif
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
- No need to send the sound event from the server when the sound is only going to be heard on the client anyway
- Also made the sound play for observers if WeaponSoundLocal is called on their client, too (not a guarantee)
  - Could potentially be improved for observers by playing the sound on the client for the local player and sending the sound to observers on the server

See https://github.com/fortressforever/fortressforever/commit/1fd986d23bf9230920ff34b73f7eb9f7137fe688#commitcomment-18106476
