### PR TITLE
Fix certain fields not getting saved in SourceTV demos

### DIFF
--- a/cl_dll/ff/ff_hud_keystate.cpp
+++ b/cl_dll/ff/ff_hud_keystate.cpp
@@ -225,11 +225,6 @@ bool CHudKeyState::ShouldDraw()
 		return false;
 
 	C_FFPlayer *pLocalPlayer = C_FFPlayer::GetLocalFFPlayer();
-
-	// this doesn't work in sourcetv demos, so don't even try
-	if ( engine->IsPlayingDemo() && engine->IsHLTV() )
-		return false;
-
 	C_FFPlayer *pTarget = C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
 
 	if( !pTarget ) 

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -355,10 +355,10 @@ LINK_ENTITY_TO_CLASS( player, CFFPlayer );
 PRECACHE_REGISTER(player);
 
 BEGIN_SEND_TABLE_NOBASE( CFFPlayer, DT_FFPlayerObserver )
-	SendPropFloat(SENDINFO(m_flNextClassSpecificSkill)),
+	SendPropTime(SENDINFO(m_flNextClassSpecificSkill)),
 	SendPropFloat( SENDINFO( m_flJetpackFuel )),
-	SendPropFloat(SENDINFO(m_flTrueAimTime)),
-	SendPropFloat(SENDINFO(m_flHitTime)),
+	SendPropTime(SENDINFO(m_flTrueAimTime)),
+	SendPropTime(SENDINFO(m_flHitTime)),
 	SendPropInt(SENDINFO(m_nButtons)),
 END_SEND_TABLE()
 
@@ -5306,7 +5306,7 @@ int CFFPlayer::OnTakeDamage(const CTakeDamageInfo &inputInfo)
 					data.m_flScale = damage;
 					data.m_nEntIndex = entindex();
 					DispatchEffect("BonusFire", data);
-				}
+	}
 			}
 		}
 	}

--- a/dlls/sendproxy.cpp
+++ b/dlls/sendproxy.cpp
@@ -139,7 +139,9 @@ void* SendProxy_OnlyToObservers( const SendProp *pProp, const void *pStruct, con
 			CBasePlayer *pPlayer = UTIL_PlayerByIndex( i );
 			if (pPlayer)
 			{
-				if (pPlayer->IsObserver() && pPlayer->GetObserverTarget() == pRecipient)
+				bool isHLTV = pPlayer->IsHLTV();
+				bool isObserverOfTarget = pPlayer->IsObserver() && pPlayer->GetObserverTarget() == pRecipient;
+				if (isHLTV || isObserverOfTarget)
 					pRecipients->SetRecipient( pPlayer->GetClientIndex() );
 			}
 		}


### PR DESCRIPTION
This will fix all the following fields not getting saved in SourceTV demos (+ pyro jetpack fuel once that's added):

```
BEGIN_SEND_TABLE_NOBASE( CFFPlayer, DT_FFPlayerObserver )
    SendPropFloat(SENDINFO(m_flNextClassSpecificSkill)),
    SendPropFloat(SENDINFO(m_flTrueAimTime)),
    SendPropFloat(SENDINFO(m_flHitTime)),
    SendPropInt(SENDINFO(m_nButtons)),
END_SEND_TABLE()
```

The one potential caveat here is that `m_nButtons` changes _a lot_, so saving it in the SourceTV demo for each player might inflate the size of demos considerably. The `m_nButtons` field is only needed for `hud_keystate`, so if we think it's too risky we could intentionally remove it from getting sent to SourceTV.
