### PR TITLE
Actually bring MIRV damage in line with frag gren (from 180 down to 145)

### DIFF
--- a/game_shared/ff/ff_grenade_base.h
+++ b/game_shared/ff/ff_grenade_base.h
@@ -43,6 +43,9 @@
 	#define GREN_ELAS 0.4f
 	#define GREN_FRIC_CONC 0.3f
 	#define GREN_ELAS_CONC 0.7f
+
+	#define FRAG_GREN_DAMAGE 145.0f
+	#define FRAG_GREN_RADIUS 270.0f
 #endif
 
 //=============================================================================

--- a/game_shared/ff/ff_grenade_mirv.cpp
+++ b/game_shared/ff/ff_grenade_mirv.cpp
@@ -39,6 +39,7 @@
 	//static ConVar mirv_ang_z_max("ffdev_mirv_ang_z_max","0",FCVAR_FF_FFDEV,"Maximum x spawn angle for mirvlets");
 	//static ConVar mirvlet_dmg("ffdev_mirvlet_dmg","180.0",FCVAR_FF_FFDEV,"Damage a single mirvlet does");
 	#define MIRVLET_DMG 145.0f
+	#define MIRV_DMG 145.0f
 #endif
 
 class CFFGrenadeMirv : public CFFGrenadeBase
@@ -59,7 +60,7 @@ public:
 #else
 	virtual void Spawn();
 	virtual void Explode( trace_t *pTrace, int bitsDamageType );
-
+	virtual float GetGrenadeDamage()		{ return MIRV_DMG; }
 #endif
 };
 

--- a/game_shared/ff/ff_grenade_mirv.cpp
+++ b/game_shared/ff/ff_grenade_mirv.cpp
@@ -38,9 +38,9 @@
 	//static ConVar mirv_ang_z_min("ffdev_mirv_ang_z_min","0",FCVAR_FF_FFDEV,"Minimum x spawn angle for mirvlets");
 	//static ConVar mirv_ang_z_max("ffdev_mirv_ang_z_max","0",FCVAR_FF_FFDEV,"Maximum x spawn angle for mirvlets");
 	//static ConVar mirvlet_dmg("ffdev_mirvlet_dmg","180.0",FCVAR_FF_FFDEV,"Damage a single mirvlet does");
-	#define MIRVLET_DMG 145.0f
-	#define MIRV_DMG 145.0f
-	#define MIRV_RADIUS 270.0f
+	#define MIRVLET_DMG FRAG_GREN_DAMAGE
+	#define MIRV_DMG FRAG_GREN_DAMAGE
+	#define MIRV_RADIUS FRAG_GREN_RADIUS
 #endif
 
 class CFFGrenadeMirv : public CFFGrenadeBase

--- a/game_shared/ff/ff_grenade_mirv.cpp
+++ b/game_shared/ff/ff_grenade_mirv.cpp
@@ -40,6 +40,7 @@
 	//static ConVar mirvlet_dmg("ffdev_mirvlet_dmg","180.0",FCVAR_FF_FFDEV,"Damage a single mirvlet does");
 	#define MIRVLET_DMG 145.0f
 	#define MIRV_DMG 145.0f
+	#define MIRV_RADIUS 270.0f
 #endif
 
 class CFFGrenadeMirv : public CFFGrenadeBase
@@ -61,6 +62,7 @@ public:
 	virtual void Spawn();
 	virtual void Explode( trace_t *pTrace, int bitsDamageType );
 	virtual float GetGrenadeDamage()		{ return MIRV_DMG; }
+	virtual float GetGrenadeRadius()		{ return MIRV_RADIUS; }
 #endif
 };
 

--- a/game_shared/ff/ff_grenade_normal.cpp
+++ b/game_shared/ff/ff_grenade_normal.cpp
@@ -31,11 +31,9 @@ public:
 	virtual void Spawn();
 	virtual const char *GetBounceSound() { return "NormalGrenade.Bounce"; }
 
-	// Jiggles: Lowered Frag damage from 180 to 126 (30% less), but kept the radius about the same
-	// AfterShock: back up to 145, 30% was too much. Radius still the same, and separated the values.
 #ifdef GAME_DLL
-	virtual float GetGrenadeDamage()		{ return 145.0f; }
-	virtual float GetGrenadeRadius()		{ return 270.0f; }
+	virtual float GetGrenadeDamage()		{ return FRAG_GREN_DAMAGE; }
+	virtual float GetGrenadeRadius()		{ return FRAG_GREN_RADIUS; }
 #endif
 
 	virtual color32 GetColour() { color32 col = { 255, 64, 64, GREN_ALPHA_DEFAULT }; return col; }


### PR DESCRIPTION
Was meant to be included in 2.4 but the MIRV change got missed in the merge or something, see:
- https://github.com/fortressforever/fortressforever/commit/da596605a65ff3780b837a2e61dd028fef292fd9
- https://github.com/fortressforever/fortressforever/commit/33cf7dff38bba3afba3a6a0b42d1cca08382c23c
- https://github.com/fortressforever/fortressforever/commit/6b4645ceeb4521d1c0d172180a27f29fc67b3701
- http://www.fortress-forever.com/changelogs/2.4

**Note**: The base grenade class uses damage to calculate radius (damage \* 1.5), which means this will drop the MIRV initial explosion radius from 270 to 217.5. The frag grenade has 145 damage and a manually set radius of 270. See [the first few columns of the table in this comment for how this will affect damage at the edge of the radius](https://github.com/fortressforever/fortressforever/issues/3#issuecomment-226916203)

~~Should we set the radius in line with frag grenades as well?~~ Done
