### PR TITLE
Fix bullets/flamethrower/etc being blocked by projectiles

### DIFF
--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -1962,6 +1962,17 @@ ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 
 bool CFFGameRules::ShouldCollide( int collisionGroup0, int collisionGroup1 )
 {
+	// HACK: bullet/hull traces use COLLISION_GROUP_NONE, so make them not collide
+	// with rockets/projectiles/weapons. Doing this before the sorting makes sure that
+	// normal objects can still collide
+	if (collisionGroup0 == COLLISION_GROUP_NONE && (
+		collisionGroup1 == COLLISION_GROUP_ROCKET ||
+		collisionGroup1 == COLLISION_GROUP_PROJECTILE ||
+		collisionGroup1 == COLLISION_GROUP_WEAPON))
+	{
+		return false;
+	}
+
 	// Do this before the groups are re-ordered. This way we can check only when
 	// one entity pushing on another, and not the other way round.
 	// This is checking for players moving into grenades


### PR DESCRIPTION
- Closes #291 

---

This is **_a**_ fix, but not necessarily a _good_ fix. The way this is written currently could have unintended side-effects, as [COLLISION_GROUP_NONE is used _a lot_ throughout the codebase](https://github.com/fortressforever/fortressforever/search?utf8=%E2%9C%93&q=COLLISION_GROUP_NONE).

An alternate solution would be to create a new COLLISION_GROUP specifically for weapon traces and make sure to use that for every relevant trace. That would be less prone to unintended side-effects (and give more fine-grained control), but we'd need to make sure that we convert everything to the new COLLISION_GROUP that should use it.

It's worth noting that bullets colliding with projectiles seems to be the default behavior of the Source SDK; as far as I can tell this behavior still exists in Source SDK 2013 (still uses COLLISION_GROUP_NONE for bullet traces, no special handling in the relevant collision functions).
