### PR TITLE
Fix voice icons on scoreboard

### DIFF
--- a/game_shared/voice_status.cpp
+++ b/game_shared/voice_status.cpp
@@ -326,9 +326,9 @@ int CVoiceStatus::GetSpeakerStatus(int entindex)
 	if ( !engine->GetPlayerInfo( entindex, &pi ) )
 		return 0;
 
-	bool bTalking = !!m_VoicePlayers[entindex];
+	bool bTalking = !!m_VoicePlayers[entindex-1];
 	bool bBanned  = m_BanMgr.GetPlayerBan(pi.guid);
-	bool bNeverSpoken = !m_VoiceEnabledPlayers[entindex];
+	bool bNeverSpoken = !m_VoiceEnabledPlayers[entindex-1];
 
 	if (bBanned)
 		return VOICE_BANNED;


### PR DESCRIPTION
 displaying the status of voice icons from someone else, and asserting when the 22nd player talks.

Closes #312 
