### PR TITLE
Fix jetpack effect staying on when you switch class while jetpacking

### DIFF
--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -822,7 +822,6 @@ BEGIN_RECV_TABLE_NOBASE( C_FFPlayer, DT_FFLocalPlayerExclusive )
 END_RECV_TABLE( )
 
 BEGIN_RECV_TABLE_NOBASE( C_FFPlayer, DT_FFNonLocalPlayerExclusive )
-	RecvPropBool( RECVINFO( m_bJetpacking ) ),
 END_RECV_TABLE( )
 
 #ifdef EXTRA_LOCAL_ORIGIN_ACCURACY
@@ -876,6 +875,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_FFPlayer, DT_FFPlayer, CFFPlayer )
 	RecvPropInt( RECVINFO( m_iCloaked ) ),
 	//RecvPropFloat( RECVINFO( m_flCloakSpeed ) ),
 	RecvPropInt( RECVINFO( m_iActiveSabotages ) ),
+	RecvPropBool( RECVINFO( m_bJetpacking ) ),
 END_RECV_TABLE( )
 
 BEGIN_PREDICTION_DATA( C_FFPlayer )

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -404,9 +404,6 @@ BEGIN_SEND_TABLE_NOBASE( CFFPlayer, DT_FFLocalPlayerExclusive )
 END_SEND_TABLE( )
 
 BEGIN_SEND_TABLE_NOBASE( CFFPlayer, DT_FFNonLocalPlayerExclusive )
-	// Send m_bJetpacking only to other players, so that the jetpacking client is its own authority for effects/sounds.
-	// This stops the jetpack sound playing twice when you have high ping.
-	SendPropBool( SENDINFO( m_bJetpacking ) ),
 END_SEND_TABLE()
 
 IMPLEMENT_SERVERCLASS_ST( CFFPlayer, DT_FFPlayer )
@@ -460,6 +457,7 @@ IMPLEMENT_SERVERCLASS_ST( CFFPlayer, DT_FFPlayer )
 	SendPropInt( SENDINFO( m_iInfectTick ) ),
 	SendPropInt( SENDINFO( m_iCloaked ), 1, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO( m_iActiveSabotages ), 2, SPROP_UNSIGNED ),
+	SendPropBool( SENDINFO( m_bJetpacking ) ),
 END_SEND_TABLE( )
 
 LINK_ENTITY_TO_CLASS( ff_ragdoll, CFFRagdoll );


### PR DESCRIPTION
- If this is released, it will cause 'Server uses different class tables' until the servers are updated

The way this worked was likely a misguided attempt at fixing #309 but without a real understanding of what was actually happening. Syncing bJetpacking to the client shouldn't be able to cause doubling of anything anymore (if it ever did).
