### PR TITLE
Add null pointer safety to fx_bonusfire

### DIFF
--- a/cl_dll/ff/ff_fx_bonusfire.cpp
+++ b/cl_dll/ff/ff_fx_bonusfire.cpp
@@ -50,7 +50,11 @@ void BonusFireCallback( const CEffectData &data )
 
 	Vector	projectileOrigin = data.m_vOrigin;
 	float	scale = data.m_flScale;
-	CBaseEntity *pAffectedEntity = ClientEntityList().GetEnt( data.m_hEntity.GetEntryIndex() );
+	CBaseEntity *pAffectedEntity = data.getEntity();
+
+	if ( !pAffectedEntity )
+		return;
+
 	Vector affectedOrigin = pAffectedEntity->GetAbsOrigin();
 	Vector deltaVec = (affectedOrigin - projectileOrigin);
 	VectorNormalize( deltaVec );


### PR DESCRIPTION
The entity sent over the network in the effect data could potentially not exist once it reaches the client, which would cause a null pointer crash

Contributes to #311
