### PR TITLE
Add discord rich presence

### DIFF
--- a/cl_dll/cdll_client_int.cpp
+++ b/cl_dll/cdll_client_int.cpp
@@ -86,6 +86,7 @@
 #include "avi/iavi.h"
 #include "hltvcamera.h"
 #include "ff_vieweffects.h"
+#include "ff_discordman.h"
 
 // BEG: Added by Mulchman for team menu at level start up
 #include <cl_dll/iviewport.h>
@@ -764,6 +765,12 @@ void CHLClient::HudUpdate( bool bActive )
 	// I don't think this is necessary any longer, but I will leave it until
 	// I can check into this further.
 	C_BaseTempEntity::CheckDynamicTempEnts();
+
+	// FF: added discord frame run so we can initialize discord sitting
+	// at the main menu. otherwise it will not initialize until we join a 
+	// server , breaking join-from-discord functionality. this might
+	// be better in a game system
+	_discord.RunFrame();
 }
 
 //-----------------------------------------------------------------------------
@@ -1129,6 +1136,9 @@ void CHLClient::LevelShutdown( void )
 #ifdef _XBOX
 	ReleaseRenderTargets();
 #endif
+
+	// FF: reset discord state since we're no longer in a map
+	_discord.Reset();
 }
 
 

--- a/cl_dll/client_scratch-2005.vcproj
+++ b/cl_dll/client_scratch-2005.vcproj
@@ -336,6 +336,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\ff_discordman.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\ff_discordman.h"
+				>
+			</File>
+			<File
 				RelativePath=".\ff\ff_glyph.cpp"
 				>
 			</File>

--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -49,7 +49,6 @@
 #include "collisionutils.h" // hlstriker: For player avoidance
 #include "history_resource.h" // squeek: For adding grens to the ammo pickups on the right
 #include "ff_mathackman.h" // squeek: For mathack manager update in ClientThink
-#include "ff_discordman.h" // for discord rich integration
 
 #if defined( CFFPlayer )
 	#undef CFFPlayer

--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -49,6 +49,7 @@
 #include "collisionutils.h" // hlstriker: For player avoidance
 #include "history_resource.h" // squeek: For adding grens to the ammo pickups on the right
 #include "ff_mathackman.h" // squeek: For mathack manager update in ClientThink
+#include "ff_discordman.h" // for discord rich integration
 
 #if defined( CFFPlayer )
 	#undef CFFPlayer
@@ -2656,6 +2657,7 @@ void C_FFPlayer::ClientThink( void )
 	}
 
 	_mathackman.Update();
+	_discord.RunFrame();
 
 	BaseClass::ClientThink();
 }

--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -2657,7 +2657,6 @@ void C_FFPlayer::ClientThink( void )
 	}
 
 	_mathackman.Update();
-	_discord.RunFrame();
 
 	BaseClass::ClientThink();
 }

--- a/cl_dll/ff/clientmode_ff.cpp
+++ b/cl_dll/ff/clientmode_ff.cpp
@@ -39,6 +39,8 @@
 #include "filesystem.h"
 #include "KeyValues.h"
 
+#include "ff_discordman.h"
+
 // Bug #0000310: fov doesn't reset |-- Mulch
 //ConVar default_fov( "default_fov", "90", FCVAR_NONE );
 ConVar default_fov( "default_fov", "90", FCVAR_ARCHIVE, "Default FOV value", true, 80.0, true, 120.0 );
@@ -79,6 +81,8 @@ void CFFModeManager::Init()
 void CFFModeManager::LevelInit( const char *newmap )
 {
 	g_pClientMode->LevelInit( newmap );
+
+	_discord.LevelInit( newmap );
 
 	// Reset client timer to zero (otherwise it'll
 	// be where we left off with the last round)

--- a/cl_dll/ff/ff_cdll_client_int.cpp
+++ b/cl_dll/ff/ff_cdll_client_int.cpp
@@ -3,6 +3,7 @@
 
 #include "filesystem.h"
 #include "ff_utils.h"
+#include "ff_discordman.h"
 #include "steam/steam_api.h"
 
 #define CLASSCFG_PATH				"cfg/%s.cfg"
@@ -27,6 +28,8 @@ int CFFClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 		pNameCvar->SetValue(SteamFriends()->GetPersonaName());
 	}
 
+	// initialize discord right away, so we can use join functionality
+	_discord.Init();
 	return ret;
 }
 

--- a/cl_dll/ff_discordman.cpp
+++ b/cl_dll/ff_discordman.cpp
@@ -121,6 +121,16 @@ void CFFDiscordManager::OnDiscordError(int errorCode, const char *szMessage)
 	Warning(buff);
 }
 
+void CFFDiscordManager::SetLogo()
+{
+	m_sDiscordRichPresence.largeImageKey = "logo-big";
+	m_sDiscordRichPresence.largeImageText = "";
+	// dont set big and small, small shows up bottom right like a notification. 
+	// class icon would be good
+	//m_sDiscordRichPresence.smallImageKey = "logo-small";
+	//m_sDiscordRichPresence.smallImageText = "";
+}
+
 void CFFDiscordManager::InitializeDiscord()
 {
 	if (!Discord_Initialize)
@@ -147,6 +157,7 @@ void CFFDiscordManager::Reset()
 	{
 		Q_memset(&m_sDiscordRichPresence, 0, sizeof(m_sDiscordRichPresence));
 		m_sDiscordRichPresence.state = "in menus";
+		SetLogo();
 		Discord_UpdatePresence(&m_sDiscordRichPresence);
 	}
 }
@@ -256,13 +267,16 @@ void CFFDiscordManager::UpdateRichPresence()
 	// we cant use time() due to relative timestamps for VCR mode
 	// dont bother with elapsed timer. kinda pointless
 	// discordPresence.startTimestamp = //time(0);
-	m_sDiscordRichPresence.largeImageKey = m_szLatchedMapname;
-	m_sDiscordRichPresence.largeImageText = m_szLatchedMapname;
+
+	// MAP THUMBNAILS
+	//m_sDiscordRichPresence.largeImageKey = m_szLatchedMapname;
+	//m_sDiscordRichPresence.largeImageText = m_szLatchedMapname;
 
 	UpdatePlayerInfo();
 	UpdateNetworkInfo();
 
-	m_sDiscordRichPresence.instance = 1;
+	//m_sDiscordRichPresence.instance = 1;
+	SetLogo();
 	Discord_UpdatePresence(&m_sDiscordRichPresence);
 }
 

--- a/cl_dll/ff_discordman.cpp
+++ b/cl_dll/ff_discordman.cpp
@@ -164,6 +164,7 @@ void CFFDiscordManager::UpdatePlayerInfo()
 	int frags = 0;
 	int deaths = 0;
 	int points = 0;
+	int teamPoints = 0;
 
 	for (int i = 1; i < maxPlayers; i++)
 	{
@@ -178,7 +179,7 @@ void CFFDiscordManager::UpdatePlayerInfo()
 				deaths = pGR->GetDeaths(i);
 				teamNum = pGR->GetTeam(i);
 				points = pGR->GetFortPoints(i);
-
+				teamPoints = pGR->GetTeamScore(teamNum);
 				// dont call Class_IntToPrintString as spec, its noisy
 				if (teamNum != TEAM_SPECTATOR)
 				{
@@ -218,7 +219,7 @@ void CFFDiscordManager::UpdatePlayerInfo()
 	}
 	else
 	{
-		Q_snprintf(m_szDetails, DISCORD_FIELD_SIZE, "%s %s %d PT %d:%d K:D", teamStr, className, points, frags, deaths);
+		Q_snprintf(m_szDetails, DISCORD_FIELD_SIZE, "%s (%d pts) - %s %d pts %d:%d K:D", teamStr, teamPoints, className, points, frags, deaths);
 	}
 
 	DevMsg("[Discord] sending details of '%s'\n", m_szDetails);

--- a/cl_dll/ff_discordman.cpp
+++ b/cl_dll/ff_discordman.cpp
@@ -148,7 +148,9 @@ void CFFDiscordManager::UpdateRichPresence()
 	Q_memset(&discordPresence, 0, sizeof(discordPresence));
 
 	
-	discordPresence.startTimestamp = time(0);
+	// we cant use time() due to relative timestamps for VCR mode
+	// dont bother with elapsed timer. kinda pointless
+	// discordPresence.startTimestamp = //time(0);
 	discordPresence.largeImageKey = m_szLatchedMapname;
 	discordPresence.largeImageText = m_szLatchedMapname;
 
@@ -211,11 +213,6 @@ void CFFDiscordManager::UpdateRichPresence()
 	
 	}
 	
-	//discordPresence.smallImageKey = "logo-small";
-	//discordPresence.smallImageText = "FF";
-	//discordPresence.partyId = "100000";// GameEngine.GetPartyId();
-		//discordPresence.matchSecret = "4b2fdce12f639de8bfa7e3591b71a0d679d7c93f";
-	//discordPresence.spectateSecret = "e7eb30d2ee025ed05c71ea495f770b76454ee4e0";
 	discordPresence.instance = 1;
 	Discord_UpdatePresence(&discordPresence);
 }
@@ -225,4 +222,6 @@ void CFFDiscordManager::LevelInit(const char *szMapname)
 	// we cant update our presence here, because if its the first map a client loaded,
 	// discord api may not yet be loaded, so latch
 	Q_strcpy(m_szLatchedMapname, szMapname);
+	// important, clear last update time as well
+	m_flLastUpdatedTime = max(0, gpGlobals->curtime - DISCORD_UPDATE_RATE);
 }

--- a/cl_dll/ff_discordman.cpp
+++ b/cl_dll/ff_discordman.cpp
@@ -140,6 +140,7 @@ void CFFDiscordManager::InitializeDiscord()
 	Q_memset(&handlers, 0, sizeof(handlers));
 	handlers.ready = &CFFDiscordManager::OnReady;
 	handlers.errored = &CFFDiscordManager::OnDiscordError;
+	// the join api is based around parties. dont bother
 	Discord_Initialize(DISCORD_APP_ID, &handlers, 1, STEAM_ID);
 }
 
@@ -289,7 +290,9 @@ void CFFDiscordManager::UpdateNetworkInfo()
 
 	// even in a private server (then needs password) this doesnt need to be secret,
 	// just set the address so other clients can get it in join request
-	m_sDiscordRichPresence.joinSecret = ni->GetAddress();
+	// TODO: dont bother setting this, its based on a client challenge system
+	// for party joins, not servers. boo
+	// m_sDiscordRichPresence.joinSecret = ni->GetAddress();
 }
 
 void CFFDiscordManager::LevelInit(const char *szMapname)

--- a/cl_dll/ff_discordman.cpp
+++ b/cl_dll/ff_discordman.cpp
@@ -207,11 +207,9 @@ void CFFDiscordManager::UpdatePlayerInfo()
 	}
 
 	// state is top line, details is box below
-	//const ConVar *hostnameCvar = cvar->FindVar("hostname");
-	//const char *szHostname = hostnameCvar->GetString();
 	if (m_szLatchedHostname[0] != '\0')
 	{
-		Q_snprintf(m_szServerInfo, DISCORD_FIELD_SIZE, "[%d/%d] %s", curPlayers, maxPlayers, m_szLatchedHostname);
+		Q_snprintf(m_szServerInfo, DISCORD_FIELD_SIZE, "[%d/%d] %s - %s", curPlayers, maxPlayers, m_szLatchedMapname, m_szLatchedHostname);
 		DevMsg("[Discord] sending state of '%s'\n", m_szServerInfo);
 		m_sDiscordRichPresence.state = m_szServerInfo;
 	}

--- a/cl_dll/ff_discordman.cpp
+++ b/cl_dll/ff_discordman.cpp
@@ -1,0 +1,139 @@
+// wrapper for discord rich presence api
+// they provide static libs, dlls and headers to use directly, but to no
+// surprise, having to use ancient vc2005 ABI, we cant even link against
+// modern DLL stub libs. Also the discord header includes stdint which vc2005 
+// doesn't even have (lol), so its mostly just manually pulling in the structs
+// and loading the library functions manually at runtime.
+
+#include "cbase.h"
+#include "ff_discordman.h"
+#include <windows.h>
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+
+#define DISCORD_LIBRARY_DLL "discord-rpc.dll"
+#define DISCORD_APP_ID "404135974801637378"
+#define STEAM_ID "253530"
+
+ConVar use_discord("cl_discord", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_USERINFO, 
+				   "Enable discord rich presence integration (current, server, map etc)");
+
+CFFDiscordManager _discord;
+
+// runtime entry point nastiness we will hide in here
+typedef void (*pDiscord_Initialize)(const char* applicationId,
+                                       DiscordEventHandlers* handlers,
+                                       int autoRegister,
+                                       const char* optionalSteamId);
+
+typedef void (*pDiscord_Shutdown)(void);
+typedef void (*pDiscord_RunCallbacks)(void);
+typedef void (*pDiscord_UpdatePresence)(const DiscordRichPresence* presence);
+
+pDiscord_Initialize Discord_Initialize = NULL;
+pDiscord_Shutdown Discord_Shutdown = NULL;
+pDiscord_RunCallbacks Discord_RunCallbacks = NULL;
+pDiscord_UpdatePresence Discord_UpdatePresence = NULL;
+
+static HINSTANCE hDiscordDLL;
+
+// NOTE: can not call discord from main menu thread. it will block
+
+CFFDiscordManager::CFFDiscordManager()
+{
+	hDiscordDLL = LoadLibrary(DISCORD_LIBRARY_DLL);
+	if (!hDiscordDLL)
+	{
+		return;
+	}
+	
+	Discord_Initialize = (pDiscord_Initialize) GetProcAddress(hDiscordDLL, "Discord_Initialize");
+	Discord_Shutdown = (pDiscord_Shutdown) GetProcAddress(hDiscordDLL, "Discord_Shutdown");
+	Discord_RunCallbacks = (pDiscord_RunCallbacks) GetProcAddress(hDiscordDLL, "Discord_RunCallbacks");
+	Discord_UpdatePresence = (pDiscord_UpdatePresence) GetProcAddress(hDiscordDLL, "Discord_UpdatePresence");
+
+	// dont run this yet. it will hang client
+	// InitializeDiscord();
+}
+
+CFFDiscordManager::~CFFDiscordManager()
+{
+	if (hDiscordDLL) 
+	{
+		// dont bother with clean exit, it will block. 
+		// Discord_Shutdown();
+		// i mean really, we could just let os handle since our dtor is called at game exit but
+		FreeLibrary(hDiscordDLL);
+	}
+	hDiscordDLL = NULL;
+}
+
+void CFFDiscordManager::RunFrame()
+{
+	if (!use_discord.GetBool())
+		return;
+
+	if (!m_bApiReady)
+	{
+		if (!m_bInitializeRequested)
+		{
+			InitializeDiscord();
+			m_bInitializeRequested = true;
+		}
+	}
+
+	// always run this, otherwise we will chicken & egg waiting for ready
+	if (Discord_RunCallbacks)
+		Discord_RunCallbacks();
+}
+
+void CFFDiscordManager::OnReady()
+{
+	DevMsg("discord ready");
+	_discord.m_bApiReady = true;
+}
+
+void CFFDiscordManager::OnDiscordError(int errorCode, const char* message)
+{
+	_discord.m_bApiReady = false;
+	if (Q_strlen(message) < 1024)
+	{
+		char buff[1024];
+		Q_snprintf(buff, 1024, "Discord init failed. code %d - error: %s\n", errorCode, message);
+		Warning(buff);
+	}
+}
+
+void CFFDiscordManager::InitializeDiscord()
+{
+	DiscordEventHandlers handlers;
+	memset(&handlers, 0, sizeof(handlers));
+	handlers.ready = &CFFDiscordManager::OnReady;
+	handlers.errored = &CFFDiscordManager::OnDiscordError;
+//	handlers.disconnected = handleDiscordDisconnected;
+//	handlers.joinGame = handleDiscordJoinGame;
+//	handlers.spectateGame = handleDiscordSpectateGame;
+//	handlers.joinRequest = handleDiscordJoinRequest;
+	Discord_Initialize(DISCORD_APP_ID, &handlers, 1, "");// STEAM_ID);
+}
+
+void CFFDiscordManager::SetServer(const char *szName)
+{
+}
+
+void CFFDiscordManager::SetMapName(const char *szDetails)
+{
+}
+
+void CFFDiscordManager::SetPlayerCounts(int min, int cur, int max)
+{
+}
+
+void CFFDiscordManager::SetSmallImage(const char *szName)
+{
+}
+
+void CFFDiscordManager::SetLargeImage(const char *szName)
+{
+}

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -60,25 +60,22 @@ public:
 	CFFDiscordManager();
 	~CFFDiscordManager();
 
-	void SetServer(const char *szName);
-	void SetMapName(const char *szDetails);
-	void SetPlayerCounts(int min, int cur, int max);
-
-	void SetSmallImage(const char *szName);
-	void SetLargeImage(const char *szName);
 	void RunFrame();
 
+	void LevelInit(const char *szMapname);
 	// these have to be static so that discord can use them
 	// as callbacks :-(
 	static void OnReady();
-	static void OnDiscordError(int errorCode, const char* message);
+	static void OnDiscordError(int errorCode, const char *szMessage);
 private:
-	
 	void InitializeDiscord();
+	void UpdateRichPresence();
 
 	// pulled out of here so we dont include windows.h
 	// including windows.h breaks CFFPlayer with a bunch of nonsense.
 	//HINSTANCE m_hDiscordDLL;
+
+	char m_szLatchedMapname[MAX_MAP_NAME];
 
 	bool m_bApiReady;
 	bool m_bInitializeRequested;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -1,5 +1,8 @@
 // ff_discordman.h
 
+#ifndef FF_DISCORDMAN_H
+#define FF_DISCORDMAN_H
+
 typedef struct DiscordRichPresence {
     const char* state;   /* max 128 bytes */
     const char* details; /* max 128 bytes */
@@ -54,15 +57,16 @@ private:
 	bool NeedToUpdate();
 
 	void UpdateRichPresence();
-	void UpdatePlayerInfo();
-	void UpdateNetworkInfo();
+	void UpdatePlayerInfo(DiscordRichPresence *pPresence);
+	void UpdateNetworkInfo(DiscordRichPresence *pPresence);
 
 	char m_szLatchedMapname[MAX_MAP_NAME];
 	bool m_bApiReady;
 	bool m_bErrored;
 	bool m_bInitializeRequested;
 	float m_flLastUpdatedTime;
-	DiscordRichPresence m_sDiscordRichPresence;
 };
 
 extern CFFDiscordManager _discord;
+
+#endif // FF_DISCORDMAN_H

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -1,0 +1,88 @@
+// ff_discordman.h
+
+// lol has stdint which vc2005 doesnt have
+//#include "discord-api/discord-rpc.h"
+#include <ctime>
+
+
+// see ff_discordman.cpp for explaination of why all this is here
+/*
+// needs lib stubs which vc2005 ABI wont link against
+__declspec(dllimport) void Discord_Initialize(const char* applicationId,
+                                       DiscordEventHandlers* handlers,
+                                       int autoRegister,
+                                       const char* optionalSteamId);
+
+__declspec(dllimport) void Discord_Shutdown(void);
+__declspec(dllimport) void Discord_RunCallbacks(void);
+__declspec(dllimport) void Discord_UpdatePresence(const DiscordRichPresence* presence);
+*/
+
+
+typedef struct DiscordRichPresence {
+    const char* state;   /* max 128 bytes */
+    const char* details; /* max 128 bytes */
+    unsigned long long startTimestamp; // type modified from stdint
+    unsigned long long endTimestamp; // type modified from stdint
+    const char* largeImageKey;  /* max 32 bytes */
+    const char* largeImageText; /* max 128 bytes */
+    const char* smallImageKey;  /* max 32 bytes */
+    const char* smallImageText; /* max 128 bytes */
+    const char* partyId;        /* max 128 bytes */
+    unsigned int partySize;
+    unsigned int partyMax;
+    const char* matchSecret;    /* max 128 bytes */
+    const char* joinSecret;     /* max 128 bytes */
+    const char* spectateSecret; /* max 128 bytes */
+    unsigned short instance; // type modified from stdint
+} DiscordRichPresence;
+
+typedef struct DiscordJoinRequest {
+    const char* userId;
+    const char* username;
+    const char* discriminator;
+    const char* avatar;
+} DiscordJoinRequest;
+
+typedef struct DiscordEventHandlers {
+    void (*ready)();
+    void (*disconnected)(int errorCode, const char* message);
+    void (*errored)(int errorCode, const char* message);
+    void (*joinGame)(const char* joinSecret);
+    void (*spectateGame)(const char* spectateSecret);
+    void (*joinRequest)(const DiscordJoinRequest* request);
+} DiscordEventHandlers;
+
+
+class CFFDiscordManager
+{
+public:
+	CFFDiscordManager();
+	~CFFDiscordManager();
+
+	void SetServer(const char *szName);
+	void SetMapName(const char *szDetails);
+	void SetPlayerCounts(int min, int cur, int max);
+
+	void SetSmallImage(const char *szName);
+	void SetLargeImage(const char *szName);
+	void RunFrame();
+
+	// these have to be static so that discord can use them
+	// as callbacks :-(
+	static void OnReady();
+	static void OnDiscordError(int errorCode, const char* message);
+private:
+	
+	void InitializeDiscord();
+
+	// pulled out of here so we dont include windows.h
+	// including windows.h breaks CFFPlayer with a bunch of nonsense.
+	//HINSTANCE m_hDiscordDLL;
+
+	bool m_bApiReady;
+	bool m_bInitializeRequested;
+	DiscordRichPresence *m_pDiscordRichPresence;
+};
+
+extern CFFDiscordManager _discord;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -4,6 +4,8 @@
 #define FF_DISCORDMAN_H
 
 #include <igameevents.h>
+#include <windows.h>
+
 #define DISCORD_FIELD_SIZE 128
 
 typedef struct DiscordRichPresence {
@@ -79,6 +81,7 @@ private:
 	char m_szDetails[DISCORD_FIELD_SIZE];
 	char m_szLatchedHostname[255];
 	char m_szLatchedMapname[MAX_MAP_NAME];
+	HINSTANCE m_hDiscordDLL;
 };
 
 extern CFFDiscordManager _discord;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -1,24 +1,5 @@
 // ff_discordman.h
 
-// lol has stdint which vc2005 doesnt have
-//#include "discord-api/discord-rpc.h"
-#include <ctime>
-
-
-// see ff_discordman.cpp for explaination of why all this is here
-/*
-// needs lib stubs which vc2005 ABI wont link against
-__declspec(dllimport) void Discord_Initialize(const char* applicationId,
-                                       DiscordEventHandlers* handlers,
-                                       int autoRegister,
-                                       const char* optionalSteamId);
-
-__declspec(dllimport) void Discord_Shutdown(void);
-__declspec(dllimport) void Discord_RunCallbacks(void);
-__declspec(dllimport) void Discord_UpdatePresence(const DiscordRichPresence* presence);
-*/
-
-
 typedef struct DiscordRichPresence {
     const char* state;   /* max 128 bytes */
     const char* details; /* max 128 bytes */
@@ -59,29 +40,25 @@ class CFFDiscordManager
 public:
 	CFFDiscordManager();
 	~CFFDiscordManager();
-
 	void RunFrame();
-
 	void LevelInit(const char *szMapname);
 	// these have to be static so that discord can use them
 	// as callbacks :-(
 	static void OnReady();
 	static void OnDiscordError(int errorCode, const char *szMessage);
+
 private:
 	void InitializeDiscord();
 	void UpdateRichPresence();
-
-	// pulled out of here so we dont include windows.h
-	// including windows.h breaks CFFPlayer with a bunch of nonsense.
-	//HINSTANCE m_hDiscordDLL;
+	bool NeedToUpdate();
+	void FillPresenceDetails();
 
 	char m_szLatchedMapname[MAX_MAP_NAME];
-
 	bool m_bApiReady;
+	bool m_bErrored;
 	bool m_bInitializeRequested;
 	float m_flLastUpdatedTime;
-
-	DiscordRichPresence *m_pDiscordRichPresence;
+	DiscordRichPresence m_sDiscordRichPresence;
 };
 
 extern CFFDiscordManager _discord;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -57,14 +57,15 @@ private:
 	bool NeedToUpdate();
 
 	void UpdateRichPresence();
-	void UpdatePlayerInfo(DiscordRichPresence *pPresence);
-	void UpdateNetworkInfo(DiscordRichPresence *pPresence);
+	void UpdatePlayerInfo();
+	void UpdateNetworkInfo();
 
 	char m_szLatchedMapname[MAX_MAP_NAME];
 	bool m_bApiReady;
 	bool m_bErrored;
 	bool m_bInitializeRequested;
 	float m_flLastUpdatedTime;
+	DiscordRichPresence m_sDiscordRichPresence;
 };
 
 extern CFFDiscordManager _discord;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -41,7 +41,9 @@ public:
 	CFFDiscordManager();
 	~CFFDiscordManager();
 	void RunFrame();
+	void Init();
 	void LevelInit(const char *szMapname);
+	void Reset();
 	// these have to be static so that discord can use them
 	// as callbacks :-(
 	static void OnReady();
@@ -49,9 +51,11 @@ public:
 
 private:
 	void InitializeDiscord();
-	void UpdateRichPresence();
 	bool NeedToUpdate();
-	void FillPresenceDetails();
+
+	void UpdateRichPresence();
+	void UpdatePlayerInfo();
+	void UpdateNetworkInfo();
 
 	char m_szLatchedMapname[MAX_MAP_NAME];
 	bool m_bApiReady;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -3,6 +3,9 @@
 #ifndef FF_DISCORDMAN_H
 #define FF_DISCORDMAN_H
 
+#include <igameevents.h>
+#define DISCORD_FIELD_SIZE 128
+
 typedef struct DiscordRichPresence {
     const char* state;   /* max 128 bytes */
     const char* details; /* max 128 bytes */
@@ -38,7 +41,7 @@ typedef struct DiscordEventHandlers {
 } DiscordEventHandlers;
 
 
-class CFFDiscordManager
+class CFFDiscordManager : public IGameEventListener2
 {
 public:
 	CFFDiscordManager();
@@ -52,6 +55,9 @@ public:
 	static void OnReady();
 	static void OnDiscordError(int errorCode, const char *szMessage);
 
+	// IGameEventListener interface:
+	virtual void FireGameEvent( IGameEvent *event);
+
 private:
 	void InitializeDiscord();
 	bool NeedToUpdate();
@@ -59,13 +65,20 @@ private:
 	void UpdateRichPresence();
 	void UpdatePlayerInfo();
 	void UpdateNetworkInfo();
-
-	char m_szLatchedMapname[MAX_MAP_NAME];
+	
 	bool m_bApiReady;
 	bool m_bErrored;
 	bool m_bInitializeRequested;
 	float m_flLastUpdatedTime;
 	DiscordRichPresence m_sDiscordRichPresence;
+
+	// scratch buffers to send in api struct. they need to persist
+	// for a short duration after api call it seemed, it must be async
+	// using a stack allocated would occassionally corrupt
+	char m_szServerInfo[DISCORD_FIELD_SIZE];
+	char m_szDetails[DISCORD_FIELD_SIZE];
+	char m_szLatchedHostname[255];
+	char m_szLatchedMapname[MAX_MAP_NAME];
 };
 
 extern CFFDiscordManager _discord;

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -79,6 +79,8 @@ private:
 
 	bool m_bApiReady;
 	bool m_bInitializeRequested;
+	float m_flLastUpdatedTime;
+
 	DiscordRichPresence *m_pDiscordRichPresence;
 };
 

--- a/cl_dll/ff_discordman.h
+++ b/cl_dll/ff_discordman.h
@@ -67,7 +67,8 @@ private:
 	void UpdateRichPresence();
 	void UpdatePlayerInfo();
 	void UpdateNetworkInfo();
-	
+	void SetLogo();
+
 	bool m_bApiReady;
 	bool m_bErrored;
 	bool m_bInitializeRequested;


### PR DESCRIPTION
Just for fun, show some info in discord rich presence. This will require the 'discord-rpc.dll' to be added to builds. however if it is not present, it will not cause issues.

Currently for details it shows the following in the discord player card:

```
<team> <team points> - <classname> <points> <k>:<d>
[1/16] server hostname blah blah
```

wonk things: for discord to properly initialize it needs to run frames when not in game, so i abused 
`CHLClient::HudUpdate()` which runs even in the main menu. alternatively, since we cant really use the join functionality, we can run it only in client player think, too (how i originally had it)