### PR TITLE
Fix ff_restartround and other events not being relayed to SourceTV

### DIFF
--- a/dlls/hltvdirector.cpp
+++ b/dlls/hltvdirector.cpp
@@ -243,6 +243,13 @@ const char** CHLTVDirector::GetModEvents()
 		"player_chat",
 		"round_start",
 		"round_end",
+		// FF specific events that are listened for on the client, so 
+		// they need to be saved in SourceTV demos, sent to SourceTV clients, etc
+		"sentrygun_killed",
+		"dispenser_killed",
+		"mancannon_killed",
+		"ff_restartround",
+		"objective_event",
 		NULL
 	};
 


### PR DESCRIPTION
Fixes things like restartround not resetting Lua HUD elements in SourceTV demos, SGs getting killed not showing up in SourceTV demos, Lua-based objective death notices not showing up in SourceTV demos, etc