### PR TITLE
Add hud_lua convar to control Lua HUD elements being drawn

### DIFF
--- a/cl_dll/ff/ff_hud_lua.cpp
+++ b/cl_dll/ff/ff_hud_lua.cpp
@@ -41,6 +41,8 @@ extern IGameUIFuncs *gameuifuncs; // for key binding details
 
 using namespace vgui;
 
+ConVar hud_lua( "hud_lua", "1", FCVAR_ARCHIVE, "When 0, stops drawing all HUD elements added by Lua" );
+
 DECLARE_HUDELEMENT(CHudLua);
 DECLARE_HUD_MESSAGE(CHudLua, FF_HudLua);
 
@@ -753,6 +755,9 @@ bool CHudLua::ShouldDraw()
 { 
 	if( !engine->IsInGame() ) 
 		return false; 
+
+	if ( !hud_lua.GetBool() )
+		return false;
 
 	C_FFPlayer *pPlayer = C_FFPlayer::GetLocalFFPlayer(); 
 


### PR DESCRIPTION
Band-aid fix for SourceTV demos not resetting Lua HUD elements properly. The other fix (#357) will only affect future demos, so this just gives an option to turn off Lua HUD elements for currently affected demos