### PR TITLE
Makes sabotaged things respect friendly fire setting

### DIFF
--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -2087,16 +2087,28 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 	// if it's a buildable, then we use the buildable's owner to perform the team checks etc. -> Defrag
 	CBasePlayer *pBuildableOwner = NULL;
 
+	bool isFriendlyFireOn = friendlyfire.GetInt() != 0;
 #ifdef GAME_DLL
 	// Special cases for sabotageable buildings
+	// Dexter 20181006: overhauled this section of code,
+	// it was a bit too sweeping, letting any sabotaged attackers or victims
+	// damage, or be damaged by anyone, regardless of friendly fire
+	// this fixes #327 , which was SG specific, but applied same
+	// treatment to detting dispensers
 
 	// If an SG is shooting its teammates then allow it to hurt them
 	if (pAttacker && pAttacker->Classify() == CLASS_SENTRYGUN)
 	{
 		CFFSentryGun *pSentry = dynamic_cast< CFFSentryGun* > (pAttacker);
 
-		if (pSentry && pSentry->IsMaliciouslySabotaged())
-			return true;
+		if ( pSentry && pSentry->IsMaliciouslySabotaged() )
+		{
+			bool victimIsSabTeammate = FFGameRules()->IsTeam1AlliedToTeam2( 
+				pVictim->GetTeamNumber(), 
+				pSentry->m_iSaboteurTeamNumber ) == GR_TEAMMATE;
+
+			return victimIsSabTeammate ? isFriendlyFireOn : true;
+		}
 	}
 	
 	if ( pVictim && pVictim->Classify() == CLASS_SENTRYGUN )
@@ -2104,10 +2116,16 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 		CFFSentryGun *pSentry = dynamic_cast <CFFSentryGun *> (pVictim);
 
 		// Allow team to kill their own SG if it is sabotaged
-		if (pSentry && pSentry->IsSabotaged())
-			return true;
+		if ( pSentry && pSentry->IsSabotaged() )
+		{
+			bool attackerIsSabTeammate = FFGameRules()->IsTeam1AlliedToTeam2( 
+				pAttacker->GetTeamNumber(), 
+				pSentry->m_iSaboteurTeamNumber ) == GR_TEAMMATE;
 
-		// if it's not sabotaged then we need to get its owner and use it later on
+			return attackerIsSabTeammate ? isFriendlyFireOn : true;
+		}
+
+ 		// if it's not sabotaged then we need to get its owner and use it later on
 		pBuildableOwner = dynamic_cast< CBasePlayer* > ( pSentry->m_hOwner.Get() );
 		
 		if( ! pBuildableOwner )
@@ -2159,7 +2177,7 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 		// If friendly fire is off and I'm not attacking myself, then
 		// someone else on my team/an ally is attacking me - don't
 		// take damage
-		if (( friendlyfire.GetInt() == 0 ) && ( pVictim != pAttacker ))
+		if ( !isFriendlyFireOn && pVictim != pAttacker )
 			return false;
 	}
 

--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -2087,7 +2087,8 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 	// if it's a buildable, then we use the buildable's owner to perform the team checks etc. -> Defrag
 	CBasePlayer *pBuildableOwner = NULL;
 
-	bool isFriendlyFireOn = friendlyfire.GetInt() != 0;
+	bool isFriendlyFireOn = friendlyfire.GetBool();
+
 #ifdef GAME_DLL
 	// Special cases for sabotageable buildings
 	// Dexter 20181006: overhauled this section of code,

--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -2138,7 +2138,13 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 		CFFDispenser *pDispenser = dynamic_cast <CFFDispenser *> (pAttacker);
 
 		if (pDispenser && pDispenser->IsSabotaged())
-			return true;
+		{
+			bool victimIsSabTeammate = FFGameRules()->IsTeam1AlliedToTeam2( 
+				pVictim->GetTeamNumber(), 
+				pDispenser->m_iSaboteurTeamNumber ) == GR_TEAMMATE;
+
+			return victimIsSabTeammate ? isFriendlyFireOn : true;
+		}
 	}
 
 	// Allow sabotaged dispensers to be destroyed by shooting
@@ -2147,7 +2153,13 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 		CFFDispenser *pDispenser = dynamic_cast <CFFDispenser *> (pVictim);
 
 		if (pDispenser && pDispenser->IsSabotaged())
-			return true;
+		{
+			bool attackerIsSabTeammate = FFGameRules()->IsTeam1AlliedToTeam2( 
+				pAttacker->GetTeamNumber(), 
+				pDispenser->m_iSaboteurTeamNumber ) == GR_TEAMMATE;
+
+			return attackerIsSabTeammate ? isFriendlyFireOn : true;
+		}
 
 		// if it's not sabotaged then we need to get its owner and use it later on
 		pBuildableOwner = dynamic_cast< CBasePlayer* > ( pDispenser->m_hOwner.Get() );


### PR DESCRIPTION
This makes sentry gun and dispenser damage given/received check friendly fire is on in respect to the saboteur's team. fixes #327 

I cannot spell saboteur correctly