### PR TITLE
Replace some explicit dynamic_cast's with `ToX` utility functions

### DIFF
--- a/dlls/ff/ff_client.cpp
+++ b/dlls/ff/ff_client.cpp
@@ -147,7 +147,7 @@ void respawn( CBaseEntity *pEdict, bool fCopyCorpse )
 		if ( fCopyCorpse )
 		{
 			// make a copy of the dead body for appearances sake
-			dynamic_cast< CBasePlayer* >( pEdict )->CreateCorpse();
+			ToBasePlayer( pEdict )->CreateCorpse();
 		}
 
 		// respawn player

--- a/dlls/ff/ff_item_flag.cpp
+++ b/dlls/ff/ff_item_flag.cpp
@@ -416,7 +416,7 @@ bool CFFInfoScript::CanEntityTouch(CBaseEntity* pEntity)
 	int classMask = kAllowScout|kAllowSniper|kAllowSoldier|kAllowDemoman|kAllowMedic|kAllowHwguy|kAllowPyro|kAllowSpy|kAllowEngineer|kAllowCivilian;
 	if(classMask & m_disallowTouchFlags && pEntity->IsPlayer() )
 	{
-		CFFPlayer *pPlayer = dynamic_cast< CFFPlayer* > ( pEntity );
+		CFFPlayer *pPlayer = ToFFPlayer ( pEntity );
 		int iClass = pPlayer->GetClassSlot();
 		switch(iClass)
 		{

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -6969,7 +6969,7 @@ void CFFPlayer::Touch(CBaseEntity *pOther)
 {
 	if (GetClassSlot() == CLASS_SCOUT || GetClassSlot() == CLASS_SPY)
 	{
-		CFFPlayer *ffplayer = dynamic_cast<CFFPlayer *> (pOther);
+		CFFPlayer *ffplayer = ToFFPlayer (pOther);
 
 		// Don't forget allies!
 		if (ffplayer && ffplayer->IsDisguised() && g_pGameRules->PlayerRelationship(this, ffplayer) == GR_NOTTEAMMATE)
@@ -7263,7 +7263,7 @@ void CFFPlayer::SpySabotageThink()
 	trace_t tr;
 	UTIL_TraceLine(EyePosition(), EyePosition() + vecForward * 100.0f, MASK_SHOT, this, COLLISION_GROUP_NONE, &tr);
 
-	CFFBuildableObject *pBuildable = dynamic_cast<CFFBuildableObject *> (tr.m_pEnt);
+	CFFBuildableObject *pBuildable = FF_ToBuildableObject (tr.m_pEnt);
 
 	// Our sabotage status has changed
 	if (pBuildable != m_hSabotaging)

--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -1242,7 +1242,7 @@ ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 				continue;
 
 			// Is this a buildable of some sort
-			CFFBuildableObject *pBuildable = dynamic_cast <CFFBuildableObject *> (info.GetInflictor());
+			CFFBuildableObject *pBuildable = FF_ToBuildableObject( info.GetInflictor() );
 
 			// Skip objects that are building
 			if(pBuildable && !pBuildable->IsBuilt()) // This is skipping buildables that are the inflictor, not the victim? Bug? - AfterShock
@@ -1500,7 +1500,7 @@ ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 		float flAdjustedDamage = flDamage;
 
 		CBaseEntity *pInflictor = info.GetInflictor();
-		bool bIsInflictorABuildable = dynamic_cast <CFFBuildableObject *> (pInflictor) != NULL;
+		bool bIsInflictorABuildable = FF_ToBuildableObject (pInflictor) != NULL;
 
 		// In TFC players only do 2/3 damage to themselves
 		// This also affects forces by the same amount
@@ -2099,7 +2099,7 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 
 	// if its a buildable, let it damage/be damaged by players based on team & friendly fire 
 	
-	CFFBuildableObject *pBuildableAttacker = dynamic_cast <CFFBuildableObject *> (pAttacker);
+	CFFBuildableObject *pBuildableAttacker = FF_ToBuildableObject( pAttacker );
 
 	if ( pBuildableAttacker && pBuildableAttacker->IsMaliciouslySabotaged() )
 	{
@@ -2110,7 +2110,7 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 		return victimIsSabTeammate ? isFriendlyFireOn : true;
 	}
 
-	CFFBuildableObject *pBuildableVictim = dynamic_cast <CFFBuildableObject *> (pVictim);
+	CFFBuildableObject *pBuildableVictim = FF_ToBuildableObject( pVictim );
 
 	if ( pBuildableVictim )
 	{
@@ -2126,7 +2126,7 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 		}
 
 		// if it's not sabotaged then we need to get its owner and use it later on
-		pBuildableOwner = dynamic_cast< CBasePlayer* > ( pBuildableVictim->m_hOwner.Get() );
+		pBuildableOwner = ToFFPlayer ( pBuildableVictim->m_hOwner.Get() );
 		
 		if( ! pBuildableOwner )
 			return false;
@@ -2142,7 +2142,7 @@ bool CFFGameRules::FCanTakeDamage( CBaseEntity *pVictim, CBaseEntity *pAttacker 
 	// Don't affect players who are chilling out
     if( pVictim->IsPlayer() )
 	{
-		CBasePlayer *pVictimPlayer = dynamic_cast< CBasePlayer* > ( pVictim );
+		CBasePlayer *pVictimPlayer = ToBasePlayer ( pVictim );
 		if( pVictimPlayer->IsObserver() || ! pVictimPlayer->IsAlive() ) 
 			return false;
 	}	

--- a/game_shared/ff/ff_projectile_grenade.cpp
+++ b/game_shared/ff/ff_projectile_grenade.cpp
@@ -127,7 +127,7 @@ PRECACHE_WEAPON_REGISTER(ff_projectile_gl);
 			// Explode on contact with people	
 			if (ExplodeOnHitPlayer()) 
 			{
-				CBasePlayer *pVictim = dynamic_cast< CBasePlayer* > ( trace.m_pEnt ); // (AFTERSHOCK): Extra damage applied to player here
+				CBasePlayer *pVictim = ToBasePlayer ( trace.m_pEnt ); // (AFTERSHOCK): Extra damage applied to player here
 
 				if (FF_IsAirshot(pVictim))
 					m_iDamageType |= DMG_AIRSHOT;
@@ -146,7 +146,7 @@ PRECACHE_WEAPON_REGISTER(ff_projectile_gl);
 		{
 			if( m_bIsLive )
 			{
-				CFFBuildableObject *pVictim = dynamic_cast< CFFBuildableObject* > ( trace.m_pEnt ); // (AFTERSHOCK): Extra damage applied to buildable here
+				CFFBuildableObject *pVictim = FF_ToBuildableObject ( trace.m_pEnt ); // (AFTERSHOCK): Extra damage applied to buildable here
 				pVictim->TakeDamage( CTakeDamageInfo( this, GetOwnerEntity(), FF_PROJECTILE_GREN_BONUSDIRECTDMG , m_iDamageType ) );
 							//CTakeDamageInfo info( this, pThrower, GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, 0, &vecReported );
 				Detonate();

--- a/game_shared/ff/ff_weapon_base.cpp
+++ b/game_shared/ff/ff_weapon_base.cpp
@@ -211,7 +211,6 @@ void CFFWeaponBase::WeaponSoundLocal( WeaponSound_t sound_type, float soundtime 
 //----------------------------------------------------------------------------
 CFFPlayer * CFFWeaponBase::GetPlayerOwner() const
 {
-	//return dynamic_cast<CFFPlayer *> (GetOwner());
 	return ToFFPlayer(GetOwner());
 }
 

--- a/game_shared/ff/ff_weapon_flamethrower.cpp
+++ b/game_shared/ff/ff_weapon_flamethrower.cpp
@@ -258,7 +258,7 @@ void CFFWeaponFlamethrower::Fire()
 				// Don't burn a guy who is underwater
 				if (traceHit.m_pEnt->IsPlayer() && ( pTarget->GetWaterLevel() < 3 ) )
 				{
-					CFFPlayer *pPlayerTarget = dynamic_cast< CFFPlayer* > ( pTarget );
+					CFFPlayer *pPlayerTarget = ToFFPlayer ( pTarget );
 					
 					int damage = GetFFWpnData().m_iDamage + CalculateBonusBurnDamage(pPlayerTarget->GetBurnLevel());
 

--- a/game_shared/ff/ff_weapon_sniperrifle.cpp
+++ b/game_shared/ff/ff_weapon_sniperrifle.cpp
@@ -557,7 +557,7 @@ void CFFWeaponSniperRifle::CheckFire()
 			}
 			else
 			{
-				ClientPrint(dynamic_cast<CBasePlayer *> (GetOwnerEntity()), HUD_PRINTCENTER, "#FF_MUSTBEONGROUND");
+				ClientPrint(ToBasePlayer (GetOwnerEntity()), HUD_PRINTCENTER, "#FF_MUSTBEONGROUND");
 				const CFFWeaponInfo &pWeaponInfo = GetFFWpnData();
 				m_flNextPrimaryAttack = gpGlobals->curtime + pWeaponInfo.m_flCycleTime;
 			}

--- a/game_shared/util_shared.cpp
+++ b/game_shared/util_shared.cpp
@@ -452,7 +452,10 @@ bool CTraceFilterSimple::ShouldHitEntity( IHandleEntity *pHandleEntity, int cont
 	{
 		if( pHandle->Classify() == CLASS_TRIGGER_CLIP )
 		{
-			CFFTriggerClip *pTriggerClip = dynamic_cast< CFFTriggerClip * >( pHandle );
+#ifdef _DEBUG
+			Assert( dynamic_cast< CFFTriggerClip * >( pHandle ) != 0 );
+#endif
+			CFFTriggerClip *pTriggerClip = static_cast< CFFTriggerClip * >( pHandle );
 			if( pTriggerClip && pTriggerClip->GetClipMask() )
 			{
 				if( pPassEnt )


### PR DESCRIPTION
Slight optimization. The `ToX` utility functions use virtual base class functions along with static_cast in non-debug builds