### PR TITLE
Fix first gren after death sometimes being thrown immediately

### DIFF
--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -526,12 +526,9 @@ CFFPlayer::CFFPlayer()
 	m_flRadioTaggedDuration = RADIOTAG_DRAW_DURATION;
 
 	// Grenade Related
-	m_iGrenadeState = FF_GREN_NONE;
-	m_flServerPrimeTime = 0;
-	m_bEngyGrenWarned = false;
+	ResetGrenadeState();
 	m_iPrimary = 0;
 	m_iSecondary = 0;
-	m_bWantToThrowGrenade = false;
 
 	// Status Effects
 	m_iBurnLevel = 0;
@@ -1376,8 +1373,7 @@ void CFFPlayer::Spawn( void )
 	m_iSabotagedDispensers = 0;
 
 	// If we get spawned, kill any primed grenades!
-	m_flServerPrimeTime = 0.0f;
-	m_iGrenadeState = FF_GREN_NONE;
+	ResetGrenadeState();
 
 	// Fixes water bug
 	if (GetWaterLevel() == 3)
@@ -1938,9 +1934,7 @@ void CFFPlayer::Event_Killed( const CTakeDamageInfo &info )
 	if (m_iGrenadeState != FF_GREN_NONE)
 	{
 		ThrowGrenade(GREN_TIMER - (gpGlobals->curtime - m_flServerPrimeTime), 0.0f);
-		m_iGrenadeState = FF_GREN_NONE;
-		m_flServerPrimeTime = 0;
-		m_bEngyGrenWarned = false;
+		ResetGrenadeState();
 	}
 	
 	/* Legshot scoring code - unfinished (ignore)
@@ -4957,6 +4951,12 @@ void CFFPlayer::Command_ThrowGren(void)
 
 	if(bThrowGrenade)
 		ThrowGrenade(fPrimeTimer);
+	
+	ResetGrenadeState();
+}
+
+void CFFPlayer::ResetGrenadeState( void )
+{
 	m_bWantToThrowGrenade = false;
 	m_iGrenadeState = FF_GREN_NONE;
 	m_flServerPrimeTime = 0.0f;
@@ -5040,9 +5040,7 @@ void CFFPlayer::GrenadeThink(void)
 	if ( (m_flServerPrimeTime != 0 ) && ( ( gpGlobals->curtime - m_flServerPrimeTime ) >= GREN_TIMER ) )
 	{
 		ThrowGrenade(0); // "throw" a grenade that immediately explodes at the player's origin
-		m_iGrenadeState = FF_GREN_NONE;
-		m_flServerPrimeTime = 0;
-		m_bEngyGrenWarned = false;
+		ResetGrenadeState();
 	}
 }
 
@@ -5155,9 +5153,7 @@ void CFFPlayer::RemovePrimedGrenades( void )
 {
 	if( IsGrenadePrimed() )
 	{
-		m_flServerPrimeTime = 0.0f;
-		m_iGrenadeState = FF_GREN_NONE;
-		m_bEngyGrenWarned = false;
+		ResetGrenadeState();
 
 		// dexter: stop all the timers beepin' away man
 		FF_SendStopGrenTimerMessage(this);

--- a/dlls/ff/ff_player.h
+++ b/dlls/ff/ff_player.h
@@ -478,6 +478,7 @@ public:
 private:	
 	void GrenadeThink(void);
 	void ThrowGrenade(float fTimer, float speed = 630.0f);		// |-- Mirv: So we can drop grens
+	void ResetGrenadeState(void);
 public:
 	void RemovePrimedGrenades( void );
 private:


### PR DESCRIPTION
m_bWantToThrowGrenade wasn't being reset on death/spawn, so if you die while throwing grens it would sometimes get stuck on and the first gren primed after spawning would immediately get thrown

This was a long-standing and very annoying bug