### PR TITLE
Fix silent grenades when client doesn't think you can prime yet

### DIFF
--- a/cl_dll/ff/c_ff_player.h
+++ b/cl_dll/ff/c_ff_player.h
@@ -61,22 +61,22 @@ bool CanStealMouseForAimSentry( void );
 //void SetStealMouseForCloak( bool bValue );
 //bool CanStealMouseForCloak( void );
 
-void CC_PrimeOne(void);
-void CC_PrimeTwo(void);
-void CC_ThrowGren(void);
+bool CC_PrimeOne(void);
+bool CC_PrimeTwo(void);
+bool CC_ThrowGren(void);
 
 // --> Mirv: More gren priming functions
-void CC_ToggleOne( void );
-void CC_ToggleTwo( void );
+bool CC_ToggleOne( void );
+bool CC_ToggleTwo( void );
 // <-- Mirv: More gren priming functions
 
-void CC_SpyCloak( void );
-void CC_SpySilentCloak( void );
-void CC_SpySmartCloak( void );
+bool CC_SpyCloak( void );
+bool CC_SpySilentCloak( void );
+bool CC_SpySmartCloak( void );
 
-void CC_EngyMe( void );
-void CC_SaveMe( void );
-void CC_AmmoMe( void );
+bool CC_EngyMe( void );
+bool CC_SaveMe( void );
+bool CC_AmmoMe( void );
 
 // Moved here from ff_shareddefs.h
 typedef struct SpyInfo_s

--- a/game_shared/ff/ff_playercommand.cpp
+++ b/game_shared/ff/ff_playercommand.cpp
@@ -186,8 +186,8 @@ FF_SHARED_COMMAND(throwgren, &CFFPlayer::Command_ThrowGren, CC_ThrowGren, "Throw
 #else
 	void CliCmdFunc_PlusGrenOne(void)
 	{
-		CC_PrimeOne();
-		if(engine->IsInGame())
+		bool shouldSend = CC_PrimeOne();
+		if(shouldSend && engine->IsInGame())
 		{
 			std::string fullcmd;
 			for(int i = 0; i < engine->Cmd_Argc(); i++)
@@ -202,8 +202,8 @@ FF_SHARED_COMMAND(throwgren, &CFFPlayer::Command_ThrowGren, CC_ThrowGren, "Throw
 	static ConCommand CliCmd_PlusGrenOne("+gren1", CliCmdFunc_PlusGrenOne, "Primes a primary grenade while the key is held.");
 	void CliCmdFunc_MinusGrenOne(void)
 	{
-		CC_ThrowGren();
-		if(engine->IsInGame())
+		bool shouldSend = CC_ThrowGren();
+		if(shouldSend && engine->IsInGame())
 		{
 			std::string fullcmd;
 			for(int i = 0; i < engine->Cmd_Argc(); i++)
@@ -218,8 +218,8 @@ FF_SHARED_COMMAND(throwgren, &CFFPlayer::Command_ThrowGren, CC_ThrowGren, "Throw
 	static ConCommand CliCmd_MinusGrenOne("-gren1", CliCmdFunc_MinusGrenOne, "Releases a primary grenade that was previously primed with +gren1.");
 	void CliCmdFunc_PlusGrenTwo(void)
 	{
-		CC_PrimeTwo();
-		if(engine->IsInGame())
+		bool shouldSend = CC_PrimeTwo();
+		if(shouldSend && engine->IsInGame())
 		{
 			std::string fullcmd;
 			for(int i = 0; i < engine->Cmd_Argc(); i++)
@@ -234,8 +234,8 @@ FF_SHARED_COMMAND(throwgren, &CFFPlayer::Command_ThrowGren, CC_ThrowGren, "Throw
 	static ConCommand CliCmd_PlusGrenTwo("+gren2", CliCmdFunc_PlusGrenTwo, "Primes a secondary grenade while the key is held.");
 	void CliCmdFunc_MinusGrenTwo(void)
 	{
-		CC_ThrowGren();
-		if(engine->IsInGame())
+		bool shouldSend = CC_ThrowGren();
+		if(shouldSend && engine->IsInGame())
 		{
 			std::string fullcmd;
 			for(int i = 0; i < engine->Cmd_Argc(); i++)

--- a/game_shared/ff/ff_playercommand.h
+++ b/game_shared/ff/ff_playercommand.h
@@ -51,8 +51,8 @@
 #define FF_SHARED_COMMAND(cmd, ServerFunc, ClientFunc, Description, Flags) \
 	void CliCmdFunc_##cmd(void) \
 	{ \
-		ClientFunc(); \
-		if(engine->IsInGame()) \
+		bool shouldSend = ClientFunc(); \
+		if(shouldSend && engine->IsInGame()) \
 		{ \
 			std::string fullcmd; \
 			for(int i = 0; i < engine->Cmd_Argc(); i++) \


### PR DESCRIPTION
Sometimes it was possible to prime a grenade but not get any timers on the client, since the command would be sent to the server even though the client thinks the command is impossible. Example: If you immediately try to prime a gren as you spawn and your latency is high enough, then the client will think you're still dead and not start the timers, but by the time the command gets to the server it will think you're alive and prime it anyway

This fixes it so that if the client thinks you can't run a command, then the command is not sent to the server. Also updated all the shared commands with this fix so this might have some side-benefits to other things like cloaking.