### PR TITLE
Nerfing the frag grenade (needs more testing)

### DIFF
--- a/game_shared/ff/ff_gamerules.cpp
+++ b/game_shared/ff/ff_gamerules.cpp
@@ -1229,8 +1229,14 @@ ConVar mp_friendlyfire_armorstrip( "mp_friendlyfire_armorstrip",
 		//NDebugOverlay::Cross3D(vecSrc, 8.0f, 255, 0, 0, true, 5.0f);
 #endif
 
+		falloff = info.GetFallOff();
+		
+		char fallOffDebugBuff[32];
+		Q_snprintf(fallOffDebugBuff, 50, "Grenade fall off: %f \n", falloff);
+		Msg(fallOffDebugBuff);
+		
 		// TFC style falloff please.
-		falloff = 0.5f; // AfterShock: need to change this if you want to have a radius over 2x the damage
+		//falloff = 0.5f; // AfterShock: need to change this if you want to have a radius over 2x the damage
 
 		// iterate on all entities in the vicinity.
 		for (CEntitySphereQuery sphere(vecSrc, flRadius); (pEntity = sphere.GetCurrentEntity()) != NULL; sphere.NextEntity()) 

--- a/game_shared/ff/ff_grenade_base.cpp
+++ b/game_shared/ff/ff_grenade_base.cpp
@@ -527,7 +527,7 @@ LINK_ENTITY_TO_CLASS(grenade_ff_base, CFFGrenadeBase);
 			CBaseEntity *pThrower = GetThrower();
 			// Use the grenade's position as the reported position
 			Vector vecReported = pTrace->endpos;
-			CTakeDamageInfo info( this, pThrower, GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, m_iKillType, &vecReported );
+			CTakeDamageInfo info( this, pThrower, GetBlastForce(), GetAbsOrigin(), m_flDamage, bitsDamageType, m_iKillType, &vecReported, GetGrenadeFallOff() );
 
 			RadiusDamage( info, GetAbsOrigin(), m_DmgRadius, CLASS_NONE, m_fIsHandheld ? pThrower : NULL );
 

--- a/game_shared/ff/ff_grenade_base.h
+++ b/game_shared/ff/ff_grenade_base.h
@@ -44,8 +44,8 @@
 	#define GREN_FRIC_CONC 0.3f
 	#define GREN_ELAS_CONC 0.7f
 
-	#define FRAG_GREN_DAMAGE 145.0f
-	#define FRAG_GREN_RADIUS 270.0f
+	#define FRAG_GREN_DAMAGE 100.0f //145.0f //Previous damage
+	#define FRAG_GREN_RADIUS 175.0f //270.0f //Previous damage radius
 #endif
 
 //=============================================================================

--- a/game_shared/ff/ff_grenade_base.h
+++ b/game_shared/ff/ff_grenade_base.h
@@ -43,9 +43,10 @@
 	#define GREN_ELAS 0.4f
 	#define GREN_FRIC_CONC 0.3f
 	#define GREN_ELAS_CONC 0.7f
+	#define GREN_FALLOFF 0.5f 
 
-	#define FRAG_GREN_DAMAGE 100.0f //145.0f //Previous damage
-	#define FRAG_GREN_RADIUS 175.0f //270.0f //Previous damage radius
+	#define FRAG_GREN_DAMAGE 145.0f
+	#define FRAG_GREN_RADIUS 270.0f
 #endif
 
 //=============================================================================
@@ -65,6 +66,7 @@ public:
 	virtual float GetGrenadeDamage()		{ return 180.0f; }
 	virtual float GetGrenadeRadius()		{ return GetGrenadeDamage() * 1.5f; }
 	virtual float GetShakeAmplitude()		{ return 2.5f; }
+	virtual float GetGrenadeFallOff()		{ return GREN_FALLOFF; }
 
 #endif
 

--- a/game_shared/ff/ff_grenade_normal.cpp
+++ b/game_shared/ff/ff_grenade_normal.cpp
@@ -34,6 +34,7 @@ public:
 #ifdef GAME_DLL
 	virtual float GetGrenadeDamage()		{ return FRAG_GREN_DAMAGE; }
 	virtual float GetGrenadeRadius()		{ return FRAG_GREN_RADIUS; }
+	virtual float GetGrenadeFallOff()		{ return 0.25f; }
 #endif
 
 	virtual color32 GetColour() { color32 col = { 255, 64, 64, GREN_ALPHA_DEFAULT }; return col; }

--- a/game_shared/takedamageinfo.cpp
+++ b/game_shared/takedamageinfo.cpp
@@ -57,6 +57,7 @@ void CTakeDamageInfo::Init( CBaseEntity *pInflictor, CBaseEntity *pAttacker, con
 	m_vecDamagePosition = damagePosition;
 	m_vecReportedPosition = reportedPosition;
 	m_iAmmoType = -1;
+	m_flFallOff = DEFAULT_FALLOFF;
 }
 
 CTakeDamageInfo::CTakeDamageInfo()
@@ -70,17 +71,18 @@ CTakeDamageInfo::CTakeDamageInfo( CBaseEntity *pInflictor, CBaseEntity *pAttacke
 	Set( pInflictor, pAttacker, flDamage, bitsDamageType, iKillType );
 }
 
-CTakeDamageInfo::CTakeDamageInfo( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType, Vector *reportedPosition )
+CTakeDamageInfo::CTakeDamageInfo( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType, Vector *reportedPosition, float flFallOff )
 {
-	Set( pInflictor, pAttacker, damageForce, damagePosition, flDamage, bitsDamageType, iKillType, reportedPosition );
+	Set( pInflictor, pAttacker, damageForce, damagePosition, flDamage, bitsDamageType, iKillType, reportedPosition, flFallOff );
 }
 
-void CTakeDamageInfo::Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, float flDamage, int bitsDamageType, int iKillType )
+void CTakeDamageInfo::Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, float flDamage, int bitsDamageType, int iKillType, float flFallOff )
 {
 	Init( pInflictor, pAttacker, vec3_origin, vec3_origin, vec3_origin, flDamage, bitsDamageType, iKillType );
+	m_flFallOff = flFallOff;
 }
 
-void CTakeDamageInfo::Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType, Vector *reportedPosition )
+void CTakeDamageInfo::Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType, Vector *reportedPosition, float flFallOff )
 {
 	Vector vecReported = vec3_origin;
 	if ( reportedPosition )
@@ -88,6 +90,7 @@ void CTakeDamageInfo::Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, cons
 		vecReported = *reportedPosition;
 	}
 	Init( pInflictor, pAttacker, damageForce, damagePosition, vecReported, flDamage, bitsDamageType, iKillType );
+	m_flFallOff = flFallOff;
 }
 
 //-----------------------------------------------------------------------------

--- a/game_shared/takedamageinfo.h
+++ b/game_shared/takedamageinfo.h
@@ -11,12 +11,12 @@
 #pragma once
 #endif
 
-
 #include "networkvar.h" // todo: change this when DECLARE_CLASS is moved into a better location.
 
 // Used to initialize m_flBaseDamage to something that we know pretty much for sure
 // hasn't been modified by a user. 
 #define BASEDAMAGE_NOT_SPECIFIED	FLT_MAX
+#define DEFAULT_FALLOFF				0.5f //Should be the same value as GREN_falloff from ff_grenade_base.h!
 
 class CBaseEntity;
 
@@ -28,7 +28,7 @@ public:
 
 					CTakeDamageInfo();
 					CTakeDamageInfo( CBaseEntity *pInflictor, CBaseEntity *pAttacker, float flDamage, int bitsDamageType, int iKillType = 0 );
-					CTakeDamageInfo( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType = 0, Vector *reportedPosition = NULL );
+					CTakeDamageInfo( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType = 0, Vector *reportedPosition = NULL, float flFallOff = DEFAULT_FALLOFF );
 	
 
 	// Inflictor is the weapon or rocket (or player) that is dealing the damage.
@@ -71,11 +71,14 @@ public:
 	void			SetAmmoType( int iAmmoType );
 	const char *	GetAmmoName() const;
 
-	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, float flDamage, int bitsDamageType, int iKillType = 0 );
-	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType = 0, Vector *reportedPosition = NULL );
+	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, float flDamage, int bitsDamageType, int iKillType = 0, float flFallOff = DEFAULT_FALLOFF );
+	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType = 0, Vector *reportedPosition = NULL, float flFallOff = DEFAULT_FALLOFF );
 
 	void			AdjustPlayerDamageInflictedForSkillLevel();
 	void			AdjustPlayerDamageTakenForSkillLevel();
+
+	float			GetFallOff() const;
+	void			SetFallOff(float falloff);
 
 #ifdef GAME_DLL
 	int				GetAmmoTypeLua( void );
@@ -99,6 +102,8 @@ protected:
 	int				m_bitsDamageType;
 	int				m_iCustomKillType;
 	int				m_iAmmoType;			// AmmoType of the weapon used to cause this damage, if any
+
+	float			m_flFallOff;
 
 	DECLARE_SIMPLE_DATADESC();
 };
@@ -295,6 +300,16 @@ inline void CTakeDamageInfo::CopyDamageToBaseDamage()
 	m_flBaseDamage = m_flDamage;
 }
 
+inline float CTakeDamageInfo::GetFallOff() const
+{
+	return m_flFallOff;
+}
+
+inline void CTakeDamageInfo::SetFallOff(float falloff)
+{
+	m_flFallOff = falloff;
+}
+
 
 // -------------------------------------------------------------------------------------------------- //
 // Inlines.
@@ -308,6 +323,5 @@ inline void CMultiDamage::SetTarget( CBaseEntity *pTarget )
 {
 	m_hTarget = pTarget;
 }
-
 
 #endif // TAKEDAMAGEINFO_H


### PR DESCRIPTION
After playing several matches and reading several posts from the community I found out that the frag grenade is OP (wow). I nerfed the frag grenade's damage from 145 to 100 (69% of the original damage) and the frag grenade's radius from 270 to 175 (65% of the original radius). However more testing needs to be done on this topic.