### PR TITLE
Properly default tickrate to 66

### DIFF
--- a/dlls/gameinterface.cpp
+++ b/dlls/gameinterface.cpp
@@ -712,11 +712,6 @@ float CServerGameDLL::GetTickInterval( void ) const
 {
 	float tickinterval = DEFAULT_TICK_INTERVAL;
 
-//#if defined( CSTRIKE_DLL )
-	// in CS reduce tickrate/sec by defualt
-	tickinterval *= 2;
-//#endif
-
 	// override if tick rate specified in command line
 	if ( CommandLine()->CheckParm( "-tickrate" ) )
 	{


### PR DESCRIPTION
This `* 2` seems erroneous and halves the default tickrate from ~66 to ~33. We add a default `-tickrate 66` command line option to our Steam release but there's no reason not to bake in the 66 tickrate since the game still has some weirdness on tickrates other than 66.