### PR TITLE
Log the map name after it's loaded for convenience

### DIFF
--- a/dlls/gameinterface.cpp
+++ b/dlls/gameinterface.cpp
@@ -910,6 +910,12 @@ bool CServerGameDLL::LevelInit( const char *pMapName, char const *pMapEntities, 
 	engine->ServerExecute();
 	// <-- Mirv
 
+	// --> FF: Log the map name for convenience. Logs on dedicated servers get split into 'loading' and 'loaded',
+	//         where only the 'loading' log has the map name, but all the 'real' stuff is in the 'loaded'
+	//         log file. This will make it so the 'loaded' log file also has the map name.
+	UTIL_LogPrintf("Loaded map \"%s\"\n", pMapName);
+	// <--
+
 	return true;
 }
 


### PR DESCRIPTION
Logs on dedicated servers get split into 'loading' and 'loaded', where only the 'loading' log has the map name, but all the 'real' stuff is in the 'loaded' log file. This will make it so the 'loaded' log file also has the map name.

The motivation here is to allow log parsers to know the map name from the relevant log file itself instead of having to get it from elsewhere.