### PR TITLE
Make bouncing off downward ramps slightly easier

### DIFF
--- a/game_shared/gamemovement.cpp
+++ b/game_shared/gamemovement.cpp
@@ -69,6 +69,9 @@ bool g_bMovementOptimizations = true;	// |-- Mirv: Changed to false, but not sur
 static ConVar sv_sharkingfriction("sv_sharkingfriction", "1", FCVAR_REPLICATED | FCVAR_CHEAT);
 #define SV_SHARKINGFRICTION sv_sharkingfriction.GetFloat()
 
+static ConVar sv_stepsize_down("sv_stepsize_down", "14", FCVAR_REPLICATED | FCVAR_CHEAT);
+#define SV_STEPSIZE_DOWN sv_stepsize_down.GetFloat()
+
 //static ConVar ffdev_headcrush_damage("ffdev_headcrush_damage", "108", FCVAR_FF_FFDEV_REPLICATED, "Straight headcrush damage; not used if usefalldamage is on");
 #define HEADCRUSH_DAMAGE 108.0f
 //static ConVar ffdev_headcrush_usefalldamage("ffdev_headcrush_usefalldamage", "4.0", FCVAR_FF_FFDEV_REPLICATED, "0 = off, > 0 means take FALLDAMAGE * val damage");
@@ -1498,7 +1501,7 @@ void CGameMovement::StayOnGround( void )
 	Vector start( mv->m_vecAbsOrigin );
 	Vector end( mv->m_vecAbsOrigin );
 	start.z += 2;
-	end.z -= player->GetStepSize();
+	end.z -= SV_STEPSIZE_DOWN;
 
 	// See how far up we can go without getting stuck
 	TracePlayerBBox( mv->m_vecAbsOrigin, start, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, trace );


### PR DESCRIPTION
- Separate out the stepsize used when stepping up stairs from the stepsize used when snapping players onto the slopes they are walking on.
- Lower the new sv_stepsize_down to 14 (previously it was using sv_stepsize which is 18)

See https://www.ryanliptak.com/blog/source-vs-goldsrc-movement-slopes/ for context

---

Really unsure about this in terms of how it will affect gameplay, just thought I'd make a PR in case it's something we ever want to do.