### PR TITLE
Lua: Add functionality to disable and enable Pyro's jetpack

### DIFF
--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -869,7 +869,6 @@ IMPLEMENT_CLIENTCLASS_DT( C_FFPlayer, DT_FFPlayer, CFFPlayer )
 	//RecvPropFloat( RECVINFO( m_flCloakSpeed ) ),
 	RecvPropInt( RECVINFO( m_iActiveSabotages ) ),
 	RecvPropBool( RECVINFO( m_bJetpacking ) ),
-	RecvPropBool( RECVINFO( m_bCanUseJetpack ) ),
 END_RECV_TABLE( )
 
 BEGIN_PREDICTION_DATA( C_FFPlayer )

--- a/cl_dll/ff/c_ff_player.cpp
+++ b/cl_dll/ff/c_ff_player.cpp
@@ -869,6 +869,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_FFPlayer, DT_FFPlayer, CFFPlayer )
 	//RecvPropFloat( RECVINFO( m_flCloakSpeed ) ),
 	RecvPropInt( RECVINFO( m_iActiveSabotages ) ),
 	RecvPropBool( RECVINFO( m_bJetpacking ) ),
+	RecvPropBool( RECVINFO( m_bCanUseJetpack ) ),
 END_RECV_TABLE( )
 
 BEGIN_PREDICTION_DATA( C_FFPlayer )

--- a/cl_dll/ff/c_ff_player.h
+++ b/cl_dll/ff/c_ff_player.h
@@ -575,7 +575,7 @@ public:
 	void JetpackHold( void );
 	void JetpackRechargeThink( void );
 	void SharedPreThink( void );
-	bool m_bCanUseJetpack;
+	CNetworkVar( bool, m_bCanUseJetpack );
 
 	// ----------------------------------
 	

--- a/cl_dll/ff/c_ff_player.h
+++ b/cl_dll/ff/c_ff_player.h
@@ -575,6 +575,8 @@ public:
 	void JetpackHold( void );
 	void JetpackRechargeThink( void );
 	void SharedPreThink( void );
+	CNetworkVar( bool, m_bCanUseJetpack );
+
 	// ----------------------------------
 	
 	// ----------------------------------

--- a/cl_dll/ff/c_ff_player.h
+++ b/cl_dll/ff/c_ff_player.h
@@ -575,7 +575,7 @@ public:
 	void JetpackHold( void );
 	void JetpackRechargeThink( void );
 	void SharedPreThink( void );
-	CNetworkVar( bool, m_bCanUseJetpack );
+	bool m_bCanUseJetpack;
 
 	// ----------------------------------
 	

--- a/dlls/ff/ff_lualib_player.cpp
+++ b/dlls/ff/ff_lualib_player.cpp
@@ -169,6 +169,8 @@ void CFFLuaLib::InitPlayer(lua_State* L)
 
 			.def("GetJetpackFuelPercent",	&CFFPlayer::GetJetpackFuelPercent)
 			.def("SetJetpackFuelPercent",	&CFFPlayer::SetJetpackFuelPercent)
+			.def("GetJetpackState",			&CFFPlayer::GetJetpackState)
+			.def("SetJetpackState",			&CFFPlayer::SetJetpackState)
 
 			.enum_("ClassId")
 			[

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -463,6 +463,7 @@ IMPLEMENT_SERVERCLASS_ST( CFFPlayer, DT_FFPlayer )
 	SendPropInt( SENDINFO( m_iCloaked ), 1, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO( m_iActiveSabotages ), 2, SPROP_UNSIGNED ),
 	SendPropBool( SENDINFO( m_bJetpacking ) ),
+	SendPropBool( SENDINFO( m_bCanUseJetpack ) ),
 END_SEND_TABLE( )
 
 LINK_ENTITY_TO_CLASS( ff_ragdoll, CFFRagdoll );
@@ -1617,6 +1618,7 @@ void CFFPlayer::SetupClassVariables()
 	m_flSpySabotageFinish = 0.0f;
 	m_hSabotaging = NULL;
 	m_bJetpacking = false;
+	m_bCanUseJetpack = true;
 
 	m_Locations.Purge();
 	m_iClientLocation = 0;
@@ -7991,4 +7993,13 @@ void CFFPlayer::SetJetpackFuelPercent(float newPct)
 {
 	float pctClamped = max(0.0f, min(newPct, 100.0f));
 	m_iJetpackFuel = (int)(200.0f * (pctClamped / 100.0f));
+}
+
+void CFFPlayer::SetJetpackState( bool bCanUseJetpack )
+{
+	m_bCanUseJetpack = bCanUseJetpack;
+}
+bool CFFPlayer::GetJetpackState()
+{
+	return m_bCanUseJetpack;
 }

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -463,7 +463,6 @@ IMPLEMENT_SERVERCLASS_ST( CFFPlayer, DT_FFPlayer )
 	SendPropInt( SENDINFO( m_iCloaked ), 1, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO( m_iActiveSabotages ), 2, SPROP_UNSIGNED ),
 	SendPropBool( SENDINFO( m_bJetpacking ) ),
-	SendPropBool( SENDINFO( m_bCanUseJetpack ) ),
 END_SEND_TABLE( )
 
 LINK_ENTITY_TO_CLASS( ff_ragdoll, CFFRagdoll );

--- a/dlls/ff/ff_player.cpp
+++ b/dlls/ff/ff_player.cpp
@@ -463,6 +463,7 @@ IMPLEMENT_SERVERCLASS_ST( CFFPlayer, DT_FFPlayer )
 	SendPropInt( SENDINFO( m_iCloaked ), 1, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO( m_iActiveSabotages ), 2, SPROP_UNSIGNED ),
 	SendPropBool( SENDINFO( m_bJetpacking ) ),
+	SendPropBool( SENDINFO( m_bCanUseJetpack ) ),
 END_SEND_TABLE( )
 
 LINK_ENTITY_TO_CLASS( ff_ragdoll, CFFRagdoll );

--- a/dlls/ff/ff_player.h
+++ b/dlls/ff/ff_player.h
@@ -781,7 +781,7 @@ public:
 
 	CNetworkVar( float, m_flNextClassSpecificSkill );
 	CNetworkVar( int, m_iJetpackFuel );
-	CNetworkVar( bool, m_bCanUseJetpack );
+	bool m_bCanUseJetpack;
 	float m_flJetpackNextFuelRechargeTime;
 
 	CNetworkVar( float, m_flConcTime );

--- a/dlls/ff/ff_player.h
+++ b/dlls/ff/ff_player.h
@@ -781,7 +781,7 @@ public:
 
 	CNetworkVar( float, m_flNextClassSpecificSkill );
 	CNetworkVar( int, m_iJetpackFuel );
-	bool m_bCanUseJetpack;
+	CNetworkVar( bool, m_bCanUseJetpack );
 	float m_flJetpackNextFuelRechargeTime;
 
 	CNetworkVar( float, m_flConcTime );

--- a/dlls/ff/ff_player.h
+++ b/dlls/ff/ff_player.h
@@ -725,6 +725,8 @@ public:
 	// for exposure to lua for cap restock
 	void SetJetpackFuelPercent( float );
 	float GetJetpackFuelPercent( void );
+	void SetJetpackState( bool );
+	bool GetJetpackState( void );
 
 	void SharedPreThink( void );
 
@@ -779,6 +781,7 @@ public:
 
 	CNetworkVar( float, m_flNextClassSpecificSkill );
 	CNetworkVar( int, m_iJetpackFuel );
+	CNetworkVar( bool, m_bCanUseJetpack );
 	float m_flJetpackNextFuelRechargeTime;
 
 	CNetworkVar( float, m_flConcTime );

--- a/game_shared/ff/ff_player_shared.cpp
+++ b/game_shared/ff/ff_player_shared.cpp
@@ -1857,6 +1857,11 @@ bool CFFPlayer::CanJetpack()
 		return false;
 	}
 
+	if (!m_bCanUseJetpack)
+	{
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Adds CFFPlayer:SetJetpackState(boolean) and CFFPlayer:GetJetpackState()

Made this so I can disable Pyro's jetpack when carrying flag but this can also be useful in other scenarios like in trimp_trainingz_b2 where the map is made before Pyro got a jetpack, Users could just fly instead of actually doing the trimp courses in the map