### PR TITLE
Fix players not being able to switch back weapons when CHudMenu is open

### DIFF
--- a/cl_dll/weapon_selection.cpp
+++ b/cl_dll/weapon_selection.cpp
@@ -463,10 +463,12 @@ void CBaseHudWeaponSelection::UserCmd_LastWeapon(void)
 	if ( !BaseClass::ShouldDraw() )
 		return;
 
+	/*
 	if ( IsHudMenuPreventingWeaponSelection() )	
 	{ 
 		return;
 	}
+	*/
 
 	SwitchToLastWeapon();
 }


### PR DESCRIPTION
Really no reason for this code to be here, its been removed since [Source SDK 2007](https://github.com/Source-SDK-Archives/source-sdk-orangebox/blob/master/game/client/weapon_selection.cpp#L473-L487).